### PR TITLE
README: Add Draft section with a proposal for event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,30 @@ This would most likely come in the form of:
 
 Would _you_ be interested in discussing this with us further?  Please join in!
 
+## Draft
 
-### Cross-Reference Issues
+### Event names
 
-#### Unit Testing Frameworks
+Based on the discussion in [#1](https://github.com/js-reporters/js-reporters/issues/1#issuecomment-54841874), this is a suggested set of event names to be triggered by a testing framework, to be consumed by reporters or other testing tools.
+
+* `runStart`: Indicates the beginning of a testsuite, triggered just once.
+* `suiteStart`: Triggered at the start of each group of tests within a testsuite.
+* `testStart`: Triggered at the start of each test.
+* `testEnd`: Triggered at the end of each test.
+* `suiteEnd`:  Triggered at the end of each group of tests within a testsuite.
+* `runEnd`:  Indicates the end of a testsuite, triggered just once.
+
+These only define event names, not the data associated with each event. The data still needs to be specified.
+
+Criteria for picking these:
+
+* These use the most common terms across a selection of frameworks, as gathered in [#1](https://github.com/js-reporters/js-reporters/issues/1#issuecomment-54841874)
+* It uses names that are valid JavaScript identifiers, which allows using those as keys in JSON and avoids the need to quote keys in regular JS objects or function calls.
+* It doesn't overlap with any known existing events, so introducing these could be done in parallel to the existing API in each framework, optionally deprecating and eventually removing the previous API.
+
+## Cross-Reference Issues
+
+### Unit Testing Frameworks
 
  - https://github.com/jquery/qunit/issues/531  (original discussion)
  - https://github.com/visionmedia/mocha/issues/1326
@@ -34,7 +54,7 @@ Would _you_ be interested in discussing this with us further?  Please join in!
  - https://github.com/caolan/nodeunit/issues/276
  - https://github.com/flatiron/vows/issues/313
 
-#### Consuming Services
+### Consuming Services
 
  - https://github.com/browserstack/browserstack-runner/issues/92
  - https://github.com/axemclion/grunt-saucelabs/issues/164


### PR DESCRIPTION
Since the discussion across all issues is stalled, I'm hoping to revive it with a more formal proposal. This is mostly an edited version of my previous comment here: https://github.com/js-reporters/js-reporters/issues/1#issuecomment-54841874

If this proposal is accepted, I'd look into event data next.

Ref #1
