### PR TITLE
add status to suites

### DIFF
--- a/lib/Data.js
+++ b/lib/Data.js
@@ -34,19 +34,30 @@ export class Suite {
         var summary = {
             passed: 0,
             failed: 0,
+            skipped: 0,
             runtime: 0
         };
 
         var allTests = this.getAllTests();
         allTests.forEach(function (test) {
-            if (test.status !== "passed") {
-                summary.failed++;
-            } else {
+            if (test.status === "passed") {
                 summary.passed++;
+            } else if (test.status === "skipped"){
+                summary.skipped++;
+            } else {
+                summary.failed++;
             }
             summary.runtime += test.runtime;
 
         });
+
+        if (summary.failed > 0) {
+            summary.status = "failed";
+        } else if (summary.passed > 0) {
+            summary.status = "passed";
+        } else {
+            summary.status = "skipped";
+        }
 
         return summary;
     }
@@ -55,13 +66,13 @@ export class Suite {
 //TODO: good idea?
 //Mocha just passes the exception thrown by the assertion library
 /*
-export class Error {
-    constructor(name, message, stack, expected, actual){
-        this.name = name;
-        this.message = message;
-        this.stack = stack;
-        this.expected = expected;
-        this.actual = actual;
-    }
-}
-/**/
+ export class Error {
+ constructor(name, message, stack, expected, actual){
+ this.name = name;
+ this.message = message;
+ this.stack = stack;
+ this.expected = expected;
+ this.actual = actual;
+ }
+ }
+ /**/


### PR DESCRIPTION
This PR fixes #19. The suite status is available at `globalSuite.getTotal().status`. `test.errors` should already be there?