### PR TITLE
Fix QUnit test

### DIFF
--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css" />
-    <script src="../../node_modules/qunitjs/qunit/qunit.js"></script>
     <script src="../../dist/js-reporters.js"></script>
+    <script src="../../node_modules/qunitjs/qunit/qunit.js"></script>
     <script src="tests.js"></script>
     <script>
 


### PR DESCRIPTION
There is an interesting bug with QUnit at the moment. QUnit defines a `module` function which tricks our umd wrapper to believe that CommonJS is present.  The workaround is to include the reporter before QUnit. I'm not really satisfied with that but I don't have a better solution. Any ideas?