### PR TITLE
Add start events

### DIFF
--- a/lib/Data.js
+++ b/lib/Data.js
@@ -9,6 +9,7 @@ export class Test {
 }
 
 export class Suite {
+
     /**
      *
      * @param name
@@ -33,19 +34,17 @@ export class Suite {
         var runtime = this.getAllTests()
             .map((x) => x.runtime)
             .reduce((sum, x) => sum + x, 0);
+
         // If one of the tests has not been run yet, its runtime is undefined.
         // If we add undefined and a number we end up with NaN.
-        if (isNaN(runtime)) {
-            return undefined;
-        } else {
-            return runtime;
-        }
+        return isNaN(runtime) ? undefined : runtime;
     }
 
     get status() {
         var passed = 0, failed = 0, skipped = 0;
 
         for (let test of this.getAllTests()) {
+
             // If a suite contains a test whose status is still undefined,
             // there is no final status for the suite as well.
             if (test.status === undefined) {

--- a/lib/Data.js
+++ b/lib/Data.js
@@ -33,6 +33,8 @@ export class Suite {
         var runtime = this.getAllTests()
             .map((x) => x.runtime)
             .reduce((sum, x) => sum + x, 0);
+        // If one of the tests has not been run yet, its runtime is undefined.
+        // If we add undefined and a number we end up with NaN.
         if (isNaN(runtime)) {
             return undefined;
         } else {

--- a/lib/Data.js
+++ b/lib/Data.js
@@ -30,22 +30,32 @@ export class Suite {
     }
 
     get runtime() {
-        return this.getAllTests()
+        var runtime = this.getAllTests()
             .map((x) => x.runtime)
             .reduce((sum, x) => sum + x, 0);
+        if (isNaN(runtime)){
+            return undefined
+        } else {
+            return runtime;
+        }
     }
 
     get status() {
         var passed = 0, failed = 0, skipped = 0;
-        this.getAllTests().forEach(function (test) {
-            if (test.status === "passed") {
+
+        for (let test of this.getAllTests()) {
+            // If a suite contains a test whose status is still undefined,
+            // there is no final status for the suite as well.
+            if (test.status === undefined) {
+                return undefined;
+            } else if (test.status === "passed") {
                 passed++;
             } else if (test.status === "skipped") {
                 skipped++;
             } else {
                 failed++;
             }
-        });
+        }
 
         if (failed > 0) {
             return "failed";

--- a/lib/Data.js
+++ b/lib/Data.js
@@ -33,8 +33,8 @@ export class Suite {
         var runtime = this.getAllTests()
             .map((x) => x.runtime)
             .reduce((sum, x) => sum + x, 0);
-        if (isNaN(runtime)){
-            return undefined
+        if (isNaN(runtime)) {
+            return undefined;
         } else {
             return runtime;
         }

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -13,23 +13,24 @@ export default class JasmineAdapter extends EventEmitter {
             suiteDone: this.onSuiteDone.bind(this),
             jasmineDone: this.onJasmineDone.bind(this)
         });
-        // a stack of test arrays. The top element on the stack is the currently active suite
-        this.tests = [[]];
-        // a stack of suite arrays
-        this.suites = [[]];
 
+        // Map internal jasmine ids to standardized test/suite objects.
         this.idObjectMap = {};
     }
 
+    /**
+     * Recursively converts a jasmine suite into a standardized suite.
+     */
     convertSuite(jasmineSuite) {
         var name = jasmineSuite.description;
         var childSuites = [];
         var tests = [];
-        for (var i = 0; i < jasmineSuite.children.length; i++) {
-            if (jasmineSuite.children[i].id.startsWith("suite")) {
-                childSuites.push(this.convertSuite(jasmineSuite.children[i]));
-            } else if (jasmineSuite.children[i].id.startsWith("spec")) {
-                tests.push(this.convertSpec(jasmineSuite.children[i]));
+        for (let child of jasmineSuite.children) {
+            // a child can be either a suite or a spec. We use the id to distinguish between the two.
+            if (child.id.startsWith("suite")) {
+                childSuites.push(this.convertSuite(child));
+            } else if (child.id.startsWith("spec")) {
+                tests.push(this.convertSpec(child));
             }
         }
         var suite = new Suite(name, childSuites, tests);
@@ -39,12 +40,13 @@ export default class JasmineAdapter extends EventEmitter {
         return suite;
     }
 
-
+    /**
+     * Converts a jasmine spec into a standardized test.
+     */
     convertSpec(jasmineSpec) {
         var testName = jasmineSpec.description;
         var suiteName = jasmineSpec.result.fullName;
-        var status;
-        var runtime = undefined;
+        var status, runtime;
         var errors = [];
 
         if (jasmineSpec.markedPending) {
@@ -52,6 +54,8 @@ export default class JasmineAdapter extends EventEmitter {
         } else {
             status = undefined;
         }
+        // Jasmine only provides a concatenated suiteName + testName string.
+        // Remove the testName from the string.
         if (suiteName.lastIndexOf(testName) === suiteName.length - testName.length) {
             suiteName = suiteName.substr(0, suiteName.length - testName.length - 1);
         }
@@ -63,6 +67,7 @@ export default class JasmineAdapter extends EventEmitter {
             runtime,
             errors);
 
+        this.idObjectMap[jasmineSpec.id] = test;
 
         return test;
     }
@@ -71,47 +76,31 @@ export default class JasmineAdapter extends EventEmitter {
     onJasmineStarted() {
         var startSuite = this.convertSuite(this.jasmine.topSuite());
         startSuite.name = "";
-        this.idObjectMap["globalSuite"] = startSuite;
+        this.idObjectMap.globalSuite = startSuite;
 
         this.emit("runStart", startSuite);
     }
 
 
-    onSpecStarted() {
+    onSpecStarted(details) {
         this.startTime = new Date();
+        this.emit("testStart", this.idObjectMap[details.id]);
     }
 
     onSpecDone(details) {
-        var runtime = new Date() - this.startTime;
-        var testName = details.description;
-        var suiteName = details.fullName;
-        var errors = details.failedExpectations;
-        var status;
+        var test = this.idObjectMap[details.id];
+        test.runtime = new Date() - this.startTime;
+        test.errors = details.failedExpectations;
         if (details.status === "pending") {
-            status = "skipped";
+            test.status = "skipped";
         } else {
-            status = details.status;
+            test.status = details.status;
         }
 
-        // Jasmine only provides a concatenated suiteName + testName string.
-        // Remove the testName from the string.
-        if (suiteName.lastIndexOf(testName) === suiteName.length - testName.length) {
-            suiteName = suiteName.substr(0, suiteName.length - testName.length - 1);
-        }
-        var test = new Test(
-            testName,
-            suiteName,
-            status,
-            runtime,
-            errors
-        );
         this.emit("testEnd", test);
-        this.tests[this.tests.length - 1].push(test);
     }
 
     onSuiteStarted(details) {
-        this.tests.push([]);
-        this.suites.push([]);
         this.emit("suiteStart", this.idObjectMap[details.id]);
     }
 
@@ -129,7 +118,7 @@ export default class JasmineAdapter extends EventEmitter {
          */
     }
 
-    onJasmineDone(details) {
-        this.emit("runEnd", this.idObjectMap["globalSuite"]);
+    onJasmineDone() {
+        this.emit("runEnd", this.idObjectMap.globalSuite);
     }
 }

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -46,13 +46,7 @@ export default class JasmineAdapter extends EventEmitter {
     convertSpec(jasmineSpec) {
         var testName = jasmineSpec.description;
         var suiteName = jasmineSpec.result.fullName;
-        var status;
 
-        if (jasmineSpec.markedPending) {
-            status = "skipped";
-        } else {
-            status = undefined;
-        }
         // Jasmine only provides a concatenated suiteName + testName string.
         // Remove the testName from the string.
         if (suiteName.lastIndexOf(testName) === suiteName.length - testName.length) {
@@ -62,7 +56,7 @@ export default class JasmineAdapter extends EventEmitter {
         var test = new Test(
             testName,
             suiteName,
-            status,
+            undefined,
             undefined,
             undefined
         );

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -1,6 +1,10 @@
 import EventEmitter from "../EventEmitter.js";
 import {Test, Suite} from "../Data.js";
 
+/**
+ * Limitations:
+ *  - Errors in afterAll are ignored.
+ */
 export default class JasmineAdapter extends EventEmitter {
     constructor(jasmine) {
         super();
@@ -15,7 +19,7 @@ export default class JasmineAdapter extends EventEmitter {
         });
 
         // Map internal jasmine ids to standardized test/suite objects.
-        this.idObjectMap = {};
+        this.idDataMap = {};
     }
 
     /**
@@ -29,13 +33,13 @@ export default class JasmineAdapter extends EventEmitter {
             // a child can be either a suite or a spec. We use the id to distinguish between the two.
             if (child.id.indexOf("suite") === 0) {
                 childSuites.push(this.convertSuite(child));
-            } else if (child.id.indexOf("spec") === 0) {
+            } else {
                 tests.push(this.convertSpec(child));
             }
         }
         var suite = new Suite(name, childSuites, tests);
 
-        this.idObjectMap[jasmineSuite.id] = suite;
+        this.idDataMap[jasmineSuite.id] = suite;
 
         return suite;
     }
@@ -55,13 +59,10 @@ export default class JasmineAdapter extends EventEmitter {
 
         var test = new Test(
             testName,
-            suiteName,
-            undefined,
-            undefined,
-            undefined
+            suiteName
         );
 
-        this.idObjectMap[jasmineSpec.id] = test;
+        this.idDataMap[jasmineSpec.id] = test;
 
         return test;
     }
@@ -69,8 +70,8 @@ export default class JasmineAdapter extends EventEmitter {
 
     onJasmineStarted() {
         var startSuite = this.convertSuite(this.jasmine.topSuite());
-        startSuite.name = "";
-        this.idObjectMap.globalSuite = startSuite;
+        startSuite.name = undefined;
+        this.idDataMap.globalSuite = startSuite;
 
         this.emit("runStart", startSuite);
     }
@@ -78,11 +79,11 @@ export default class JasmineAdapter extends EventEmitter {
 
     onSpecStarted(details) {
         this.startTime = new Date();
-        this.emit("testStart", this.idObjectMap[details.id]);
+        this.emit("testStart", this.idDataMap[details.id]);
     }
 
     onSpecDone(details) {
-        var test = this.idObjectMap[details.id];
+        var test = this.idDataMap[details.id];
         test.runtime = new Date() - this.startTime;
         test.errors = details.failedExpectations;
         if (details.status === "pending") {
@@ -95,24 +96,14 @@ export default class JasmineAdapter extends EventEmitter {
     }
 
     onSuiteStarted(details) {
-        this.emit("suiteStart", this.idObjectMap[details.id]);
+        this.emit("suiteStart", this.idDataMap[details.id]);
     }
 
     onSuiteDone(details) {
-
-        this.emit("suiteEnd", this.idObjectMap[details.id]);
-
-        /*
-         FIXME: Jasmine Suite may have failedExpectations caused by a failure in afterAll.
-         Changing the number of tests during runtime seems like a bad idea
-
-         if (details.failedExpectations.length > 0) {
-         this.tests[this.tests.length - 1].push(new Test("afterAll", "failed", 0));
-         }
-         */
+        this.emit("suiteEnd", this.idDataMap[details.id]);
     }
 
     onJasmineDone() {
-        this.emit("runEnd", this.idObjectMap.globalSuite);
+        this.emit("runEnd", this.idDataMap.globalSuite);
     }
 }

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -30,6 +30,7 @@ export default class JasmineAdapter extends EventEmitter {
         var childSuites = [];
         var tests = [];
         for (let child of jasmineSuite.children) {
+
             // a child can be either a suite or a spec. We use the id to distinguish between the two.
             if (child.id.indexOf("suite") === 0) {
                 childSuites.push(this.convertSuite(child));

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -4,7 +4,9 @@ import {Test, Suite} from "../Data.js";
 export default class JasmineAdapter extends EventEmitter {
     constructor(jasmine) {
         super();
+        this.jasmine = jasmine;
         jasmine.addReporter({
+            jasmineStarted: this.onJasmineStarted.bind(this),
             specDone: this.onSpecDone.bind(this),
             specStarted: this.onSpecStarted.bind(this),
             suiteStarted: this.onSuiteStarted.bind(this),
@@ -15,6 +17,63 @@ export default class JasmineAdapter extends EventEmitter {
         this.tests = [[]];
         // a stack of suite arrays
         this.suites = [[]];
+
+        this.idObjectMap = {};
+    }
+
+    convertSuite(jasmineSuite) {
+        var name = jasmineSuite.description;
+        var childSuites = [];
+        var tests = [];
+        for (var i = 0; i < jasmineSuite.children.length; i++) {
+            if (jasmineSuite.children[i].id.startsWith("suite")) {
+                childSuites.push(this.convertSuite(jasmineSuite.children[i]));
+            } else if (jasmineSuite.children[i].id.startsWith("spec")) {
+                tests.push(this.convertSpec(jasmineSuite.children[i]));
+            }
+        }
+        var suite = new Suite(name, childSuites, tests);
+
+        this.idObjectMap[jasmineSuite.id] = suite;
+
+        return suite;
+    }
+
+
+    convertSpec(jasmineSpec) {
+        var testName = jasmineSpec.description;
+        var suiteName = jasmineSpec.result.fullName;
+        var status;
+        var runtime = undefined;
+        var errors = [];
+
+        if (jasmineSpec.markedPending) {
+            status = "skipped";
+        } else {
+            status = undefined;
+        }
+        if (suiteName.lastIndexOf(testName) === suiteName.length - testName.length) {
+            suiteName = suiteName.substr(0, suiteName.length - testName.length - 1);
+        }
+
+        var test = new Test(
+            testName,
+            suiteName,
+            status,
+            runtime,
+            errors);
+
+
+        return test;
+    }
+
+
+    onJasmineStarted() {
+        var startSuite = this.convertSuite(this.jasmine.topSuite());
+        startSuite.name = "";
+        this.idObjectMap["globalSuite"] = startSuite;
+
+        this.emit("runStart", startSuite);
     }
 
 
@@ -50,22 +109,27 @@ export default class JasmineAdapter extends EventEmitter {
         this.tests[this.tests.length - 1].push(test);
     }
 
-    onSuiteStarted() {
+    onSuiteStarted(details) {
         this.tests.push([]);
         this.suites.push([]);
+        this.emit("suiteStart", this.idObjectMap[details.id]);
     }
 
     onSuiteDone(details) {
-        if (details.failedExpectations.length > 0) {
-            this.tests[this.tests.length - 1].push(new Test("afterAll", "failed", 0));
-        }
-        var suite = new Suite(details.description, this.suites.pop(), this.tests.pop());
-        this.emit("suiteEnd", suite);
-        this.suites[this.suites.length - 1].push(suite);
+
+        this.emit("suiteEnd", this.idObjectMap[details.id]);
+
+        /*
+         FIXME: Jasmine Suite may have failedExpectations caused by a failure in afterAll.
+         Changing the number of tests during runtime seems like a bad idea
+
+         if (details.failedExpectations.length > 0) {
+         this.tests[this.tests.length - 1].push(new Test("afterAll", "failed", 0));
+         }
+         */
     }
 
-    onJasmineDone() {
-        var globalSuite = new Suite("", this.suites.pop(), this.tests.pop());
-        this.emit("runEnd", globalSuite);
+    onJasmineDone(details) {
+        this.emit("runEnd", this.idObjectMap["globalSuite"]);
     }
 }

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -27,9 +27,9 @@ export default class JasmineAdapter extends EventEmitter {
         var tests = [];
         for (let child of jasmineSuite.children) {
             // a child can be either a suite or a spec. We use the id to distinguish between the two.
-            if (child.id.startsWith("suite")) {
+            if (child.id.indexOf("suite") === 0) {
                 childSuites.push(this.convertSuite(child));
-            } else if (child.id.startsWith("spec")) {
+            } else if (child.id.indexOf("spec") === 0) {
                 tests.push(this.convertSpec(child));
             }
         }
@@ -46,8 +46,7 @@ export default class JasmineAdapter extends EventEmitter {
     convertSpec(jasmineSpec) {
         var testName = jasmineSpec.description;
         var suiteName = jasmineSpec.result.fullName;
-        var status, runtime;
-        var errors = [];
+        var status;
 
         if (jasmineSpec.markedPending) {
             status = "skipped";
@@ -64,8 +63,9 @@ export default class JasmineAdapter extends EventEmitter {
             testName,
             suiteName,
             status,
-            runtime,
-            errors);
+            undefined,
+            undefined
+        );
 
         this.idObjectMap[jasmineSpec.id] = test;
 

--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -32,6 +32,8 @@ export default class QUnitAdapter extends EventEmitter {
 
     onBegin() {
         var suites = [];
+
+        // Access QUnit internals to build liste of modules, working around missing event data
         for (let suite of this.QUnit.config.modules) {
             suites.push(this.convertModule(suite));
         }

--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -5,18 +5,52 @@ import {Test, Suite} from "../Data.js";
 export default class QUnitAdapter extends EventEmitter {
     constructor() {
         super();
-        QUnit.done(this.onDone.bind(this));
+        QUnit.config.reorder = false;
+        QUnit.begin(this.onBegin.bind(this));
+        QUnit.moduleStart(this.onModuleStart.bind(this));
+        QUnit.testStart(this.onTestStart.bind(this));
+        QUnit.log(this.onLog.bind(this));
         QUnit.testDone(this.onTestDone.bind(this));
         QUnit.moduleDone(this.onModuleDone.bind(this));
-        QUnit.log(this.onLog.bind(this));
-        QUnit.testStart(this.onTestStart.bind(this));
+        QUnit.done(this.onDone.bind(this));
 
-        this.tests = {};
-        this.suites = [];
+        this.idObjectMap = {};
     }
 
-    onTestStart() {
+    convertModule(qunitModule) {
+        var name = qunitModule.name;
+        var childSuites = [];
+        var tests = [];
+        for (let test of qunitModule.tests) {
+            var jsTest = new Test(test.name, qunitModule.name, undefined, undefined, undefined);
+            tests.push(jsTest);
+            this.idObjectMap[test.testId] = jsTest;
+        }
+
+        var suite = new Suite(name, childSuites, tests);
+
+        this.idObjectMap[qunitModule.name] = suite;
+
+        return suite;
+    }
+
+    onBegin() {
+        var suites = [];
+        for (let suite of QUnit.config.modules) {
+            suites.push(this.convertModule(suite));
+        }
+
+        this.idObjectMap.globalSuite = new Suite("", suites, []);
+        this.emit("runStart", this.idObjectMap.globalSuite);
+    }
+
+    onModuleStart(details) {
+        this.emit("suiteStart", this.idObjectMap[details.name]);
+    }
+
+    onTestStart(details) {
         this.errors = [];
+        this.emit("testStart", this.idObjectMap[details.testId]);
     }
 
     onLog(details) {
@@ -26,49 +60,28 @@ export default class QUnitAdapter extends EventEmitter {
     }
 
     onTestDone(details) {
-        var status;
+        var test = this.idObjectMap[details.testId];
+
         if (details.failed !== 0) {
-            status = "failed";
+            test.status = "failed";
         } else if (details.skipped === true) {
-            status = "skipped";
+            test.status = "skipped";
         } else {
-            status = "passed";
+            test.status = "passed";
         }
 
-        var test = new Test(
-            details.name,
-            details.module,
-            status,
-            details.runtime,
-            this.errors
-        );
-        this.tests[details.testId] = test;
+        test.runtime = details.runtime;
+        test.errors = this.errors;
+
         this.emit("testEnd", test);
     }
 
-    onDone() {
-        var globalSuite = new Suite("", this.suites, []);
-        this.emit("runEnd", globalSuite);
-    }
 
     onModuleDone(details) {
-        for (var test of details.tests) {
-            // check if the module is actually finished:
-            // QUnit may trigger moduleDone multiple times if it reorders tests
-            // if not, return and wait for the next moduleDone
-            // https://github.com/jquery/qunit/issues/830
-            if (!(test.testId in this.tests)) {
-                return;
-            }
-        }
-        var testArray = [];
-        for (test of details.tests) {
-            testArray.push(this.tests[test.testId]);
-            delete this.tests[test.testId];
-        }
+        this.emit("suiteEnd", this.idObjectMap[details.name]);
+    }
 
-        var suite = new Suite(details.name, [], testArray);
-        this.suites.push(suite);
-        this.emit("suiteEnd", suite);
+    onDone() {
+        this.emit("runEnd", this.idObjectMap.globalSuite);
     }
 }

--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -1,11 +1,10 @@
 import EventEmitter from "../EventEmitter.js";
 import {Test, Suite} from "../Data.js";
 
-/*global QUnit*/
 export default class QUnitAdapter extends EventEmitter {
-    constructor() {
+    constructor(QUnit) {
         super();
-        QUnit.config.reorder = false;
+        this.QUnit = QUnit;
         QUnit.begin(this.onBegin.bind(this));
         QUnit.moduleStart(this.onModuleStart.bind(this));
         QUnit.testStart(this.onTestStart.bind(this));
@@ -14,43 +13,40 @@ export default class QUnitAdapter extends EventEmitter {
         QUnit.moduleDone(this.onModuleDone.bind(this));
         QUnit.done(this.onDone.bind(this));
 
-        this.idObjectMap = {};
+        this.idDataMap = {};
     }
 
     convertModule(qunitModule) {
-        var name = qunitModule.name;
-        var childSuites = [];
+        var suiteName = qunitModule.name;
         var tests = [];
-        for (let test of qunitModule.tests) {
-            var jsTest = new Test(test.name, qunitModule.name, undefined, undefined, undefined);
-            tests.push(jsTest);
-            this.idObjectMap[test.testId] = jsTest;
+        for (let qunitTest of qunitModule.tests) {
+            let test = new Test(qunitTest.name, suiteName);
+            tests.push(test);
+            this.idDataMap[qunitTest.testId] = test;
         }
 
-        var suite = new Suite(name, childSuites, tests);
-
-        this.idObjectMap[qunitModule.name] = suite;
-
+        var suite = new Suite(suiteName, [], tests);
+        this.idDataMap[qunitModule.name] = suite;
         return suite;
     }
 
     onBegin() {
         var suites = [];
-        for (let suite of QUnit.config.modules) {
+        for (let suite of this.QUnit.config.modules) {
             suites.push(this.convertModule(suite));
         }
 
-        this.idObjectMap.globalSuite = new Suite("", suites, []);
-        this.emit("runStart", this.idObjectMap.globalSuite);
+        this.idDataMap.globalSuite = new Suite(undefined, suites, []);
+        this.emit("runStart", this.idDataMap.globalSuite);
     }
 
     onModuleStart(details) {
-        this.emit("suiteStart", this.idObjectMap[details.name]);
+        this.emit("suiteStart", this.idDataMap[details.name]);
     }
 
     onTestStart(details) {
         this.errors = [];
-        this.emit("testStart", this.idObjectMap[details.testId]);
+        this.emit("testStart", this.idDataMap[details.testId]);
     }
 
     onLog(details) {
@@ -60,7 +56,7 @@ export default class QUnitAdapter extends EventEmitter {
     }
 
     onTestDone(details) {
-        var test = this.idObjectMap[details.testId];
+        var test = this.idDataMap[details.testId];
 
         if (details.failed !== 0) {
             test.status = "failed";
@@ -78,10 +74,10 @@ export default class QUnitAdapter extends EventEmitter {
 
 
     onModuleDone(details) {
-        this.emit("suiteEnd", this.idObjectMap[details.name]);
+        this.emit("suiteEnd", this.idDataMap[details.name]);
     }
 
     onDone() {
-        this.emit("runEnd", this.idObjectMap.globalSuite);
+        this.emit("runEnd", this.idDataMap.globalSuite);
     }
 }

--- a/lib/reporters/ConsoleReporter.js
+++ b/lib/reporters/ConsoleReporter.js
@@ -5,6 +5,7 @@ export default class ConsoleReporter {
     constructor(runner) {
         runner.on("runStart", this.onRunStart);
         runner.on("suiteStart", this.onSuiteStart);
+        runner.on("testStart", this.onTestStart);
         runner.on("testEnd", this.onTestEnd);
         runner.on("suiteEnd", this.onSuiteEnd);
         runner.on("runEnd", this.onRunEnd);
@@ -14,14 +15,19 @@ export default class ConsoleReporter {
         return new ConsoleReporter(runner);
     }
 
-    onRunStart(suite){
-        console.log("runStart", suite)
+    onRunStart(suite) {
+        console.log("runStart", suite);
     }
 
     onSuiteStart(suite) {
         if (hasGrouping) {
             console.group(suite.name);
         }
+        console.log("suiteStart", suite);
+    }
+
+    onTestStart(test) {
+        console.log("testStart", test);
     }
 
     onTestEnd(test) {

--- a/lib/reporters/ConsoleReporter.js
+++ b/lib/reporters/ConsoleReporter.js
@@ -3,6 +3,7 @@ var hasGrouping = "group" in console && "groupEnd" in console;
 
 export default class ConsoleReporter {
     constructor(runner) {
+        runner.on("runStart", this.onRunStart);
         runner.on("suiteStart", this.onSuiteStart);
         runner.on("testEnd", this.onTestEnd);
         runner.on("suiteEnd", this.onSuiteEnd);
@@ -11,6 +12,10 @@ export default class ConsoleReporter {
 
     static init(runner) {
         return new ConsoleReporter(runner);
+    }
+
+    onRunStart(suite){
+        console.log("runStart", suite)
     }
 
     onSuiteStart(suite) {

--- a/lib/reporters/TestReporter.js
+++ b/lib/reporters/TestReporter.js
@@ -29,7 +29,7 @@ export default class TestReporter {
 
         if (eventName !== expectedEventName || !this.equal(eventData, expectedEventData)) {
             this.error = true;
-            console.error("expected:", expectedEventName, expectedEventData, "actual:", eventName, eventData);
+            console.error("expected:", expectedEventName, expectedEventData, "\r\n", "actual:", eventName, eventData);
         }
     }
 
@@ -64,11 +64,13 @@ export default class TestReporter {
                     return false;
                 }
             }
-            if (typeof actual.runtime !== "number") {
+            if (typeof actual.runtime !== "number" && actual.runtime !== undefined) {
                 return false;
             }
 
-            if (actual.errors.length !== expected.errors.length) {
+
+            if (!(actual.errors === undefined && expected.errors === undefined) &&
+                actual.errors.length !== expected.errors.length) {
                 return false;
             }
 

--- a/lib/reporters/TestReporter.js
+++ b/lib/reporters/TestReporter.js
@@ -6,6 +6,7 @@ import {Test, Suite} from "../Data.js";
  The result is given in the ok attribute.
  */
 export default class TestReporter {
+
     /**
      * @param runner: standardized test runner (or adapter)
      * @param referenceData: An array of all expected (eventName, eventData) tuples in the right order

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "mkdirp dist/ && esperanto -b -i lib/index.js -t umd --name JsReporters | babel -o dist/js-reporters.js --blacklist strict -m umd",
-    "lint": "eslint lib/",
+    "lint": "eslint lib/ test/",
     "test": "node test/test.js"
   },
   "devDependencies": {
@@ -18,7 +18,8 @@
   },
   "eslintConfig": {
     "env": {
-      "es6": true
+      "es6": true,
+      "node": true
     },
     "ecmaFeatures": {
       "modules": true

--- a/package.json
+++ b/package.json
@@ -27,7 +27,14 @@
     "rules": {
       "no-console": 0,
       "brace-style": 1,
-      "space-before-blocks": 1
+      "space-before-blocks": 1,
+      "lines-around-comment": [
+        1,
+        {
+          "beforeBlockComment": true,
+          "beforeLineComment": true
+        }
+      ]
     },
     "globals": {
       "console": false

--- a/test/jasmine/tests.js
+++ b/test/jasmine/tests.js
@@ -1,3 +1,4 @@
+/*global describe, it, expect, xit*/
 describe("group a", function () {
     it("foo", function () {
         expect(5).toBe(5);

--- a/test/qunit/index.html
+++ b/test/qunit/index.html
@@ -9,8 +9,7 @@
     <script src="tests.js"></script>
     <script>
         QUnit.config.reorder = false;
-
-        var runner = new JsReporters.QUnitAdapter();
+        var runner = new JsReporters.QUnitAdapter(QUnit);
 
         //JsReporters.TapReporter.init(runner);
         JsReporters.ConsoleReporter.init(runner);

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -1,3 +1,4 @@
+/*global QUnit*/
 QUnit.module("group a");
 QUnit.test("foo", function (assert) {
     assert.equal(5, "5");
@@ -12,5 +13,5 @@ QUnit.test("baz", function (assert) {
     assert.ok(true);
 });
 QUnit.skip("skipped test", function (assert) {
-    assert.ok(true)
+    assert.ok(true);
 });

--- a/test/referenceData.js
+++ b/test/referenceData.js
@@ -15,6 +15,7 @@ var parent = new Suite("group with subgroup", [subgroup], []);
 
 // Global Suite for QUnit
 var globalSuiteNoNesting = new Suite(undefined, [groupA, groupB], []);
+
 // Global Suite for Jasmine
 var globalSuiteNesting = new Suite(undefined, [groupA, groupB, parent], []);
 

--- a/test/referenceData.js
+++ b/test/referenceData.js
@@ -19,16 +19,10 @@ var globalSuiteNoNesting = new Suite("", [groupA, groupB], []);
 var globalSuiteNesting = new Suite("", [groupA, groupB, parent], []);
 
 function toStartTest(test) {
-    var status;
-    if (test.status === "skipped") {
-        status = "skipped";
-    } else {
-        status = undefined;
-    }
     return new Test(
         test.testName,
         test.suiteName,
-        status,
+        undefined,
         undefined,
         undefined
     );
@@ -78,7 +72,7 @@ exports.Jasmine = [].concat(
 );
 
 exports.QUnit = [].concat(
-    //[["runStart", convertSuite(globalSuiteNoNesting)]],
+    [["runStart", toStartSuite(globalSuiteNoNesting)]],
     runGroupA,
     runGroupB,
     [["runEnd", globalSuiteNoNesting]]

--- a/test/referenceData.js
+++ b/test/referenceData.js
@@ -14,17 +14,14 @@ var subgroup = new Suite("subgroup", [], [subtest]);
 var parent = new Suite("group with subgroup", [subgroup], []);
 
 // Global Suite for QUnit
-var globalSuiteNoNesting = new Suite("", [groupA, groupB], []);
+var globalSuiteNoNesting = new Suite(undefined, [groupA, groupB], []);
 // Global Suite for Jasmine
-var globalSuiteNesting = new Suite("", [groupA, groupB, parent], []);
+var globalSuiteNesting = new Suite(undefined, [groupA, groupB, parent], []);
 
 function toStartTest(test) {
     return new Test(
         test.testName,
-        test.suiteName,
-        undefined,
-        undefined,
-        undefined
+        test.suiteName
     );
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
-var Jasmine = require('jasmine');
-var JsReporters = require('../dist/js-reporters.js');
-var referenceData = require('./referenceData.js');
+/* eslint camelcase:0 */
+var Jasmine = require("jasmine");
+var JsReporters = require("../dist/js-reporters.js");
+var referenceData = require("./referenceData.js");
 
 var jasmine = new Jasmine();
 jasmine.loadConfig({
@@ -10,8 +11,11 @@ jasmine.loadConfig({
     ]
 });
 
-var runner =  new JsReporters.JasmineAdapter(jasmine);
+var runner = new JsReporters.JasmineAdapter(jasmine.env);
+jasmine.addReporter({}); // Suppress the default reporter
 var testReporter = new JsReporters.TestReporter(runner, referenceData.Jasmine);
 
 jasmine.execute();
-process.exit(testReporter.ok ? 0 : 1);
+if (!testReporter.ok) {
+    throw new Error("Tests for JasmineAdapter failed!");
+}

--- a/test/test.js
+++ b/test/test.js
@@ -19,27 +19,18 @@ var jasmineTestReporter = new JsReporters.TestReporter(jasmineRunner, referenceD
 
 jasmine.execute();
 if (!jasmineTestReporter.ok) {
-    throw new Error("Tests for JasmineAdapter failed!");
+    process.exit(1);
 }
 
-//TODO: Use a proper test framework?
-var done = new Promise(function (resolve) {
-    QUnit.done(function () {
-        resolve();
-    });
+QUnit.done(function () {
+    process.exit(qunitTestReporter.ok ? 0 : 1);
 });
 
 var qunitRunner = new JsReporters.QUnitAdapter(QUnit);
 var qunitTestReporter = new JsReporters.TestReporter(qunitRunner, referenceData.QUnit);
 
 QUnit.config.autorun = false;
-QUnit.config.reorder = false;
 
 require("./qunit/tests.js");
 
 QUnit.load();
-
-done.then(function () {
-    // This is async, throwing an error doesn't change the exit code.
-    process.exit(qunitTestReporter.ok ? 0 : 1);
-});

--- a/test/test.js
+++ b/test/test.js
@@ -22,12 +22,12 @@ if (!jasmineTestReporter.ok) {
     process.exit(1);
 }
 
+var qunitRunner = new JsReporters.QUnitAdapter(QUnit);
+var qunitTestReporter = new JsReporters.TestReporter(qunitRunner, referenceData.QUnit);
+
 QUnit.done(function () {
     process.exit(qunitTestReporter.ok ? 0 : 1);
 });
-
-var qunitRunner = new JsReporters.QUnitAdapter(QUnit);
-var qunitTestReporter = new JsReporters.TestReporter(qunitRunner, referenceData.QUnit);
 
 QUnit.config.autorun = false;
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,9 @@
 /* eslint camelcase:0 */
 var Jasmine = require("jasmine");
+QUnit = require("qunitjs");
 var JsReporters = require("../dist/js-reporters.js");
 var referenceData = require("./referenceData.js");
+
 
 var jasmine = new Jasmine();
 jasmine.loadConfig({
@@ -11,11 +13,19 @@ jasmine.loadConfig({
     ]
 });
 
-var runner = new JsReporters.JasmineAdapter(jasmine.env);
+var jasmineRunner = new JsReporters.JasmineAdapter(jasmine.env);
 jasmine.addReporter({}); // Suppress the default reporter
-var testReporter = new JsReporters.TestReporter(runner, referenceData.Jasmine);
+var jasmineTestReporter = new JsReporters.TestReporter(jasmineRunner, referenceData.Jasmine);
 
 jasmine.execute();
-if (!testReporter.ok) {
+if (!jasmineTestReporter.ok) {
     throw new Error("Tests for JasmineAdapter failed!");
 }
+
+QUnit.config.autorun = false;
+
+require("./qunit/tests.js");
+var qunitRunner = new JsReporters.QUnitAdapter();
+var qunitTestReporter = new JsReporters.TestReporter(qunitRunner, referenceData.QUnit);
+
+QUnit.load();

--- a/test/test.js
+++ b/test/test.js
@@ -29,15 +29,17 @@ var done = new Promise(function (resolve) {
     });
 });
 
-var qunitRunner = new JsReporters.QUnitAdapter();
+var qunitRunner = new JsReporters.QUnitAdapter(QUnit);
 var qunitTestReporter = new JsReporters.TestReporter(qunitRunner, referenceData.QUnit);
 
 QUnit.config.autorun = false;
+QUnit.config.reorder = false;
 
 require("./qunit/tests.js");
 
 QUnit.load();
 
 done.then(function () {
+    // This is async, throwing an error doesn't change the exit code.
     process.exit(qunitTestReporter.ok ? 0 : 1);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
-/* eslint camelcase:0 */
+/* eslint camelcase:0, no-process-exit:0 */
 var Jasmine = require("jasmine");
-QUnit = require("qunitjs");
+var QUnit = require("qunitjs");
 var JsReporters = require("../dist/js-reporters.js");
 var referenceData = require("./referenceData.js");
 
@@ -22,10 +22,22 @@ if (!jasmineTestReporter.ok) {
     throw new Error("Tests for JasmineAdapter failed!");
 }
 
-QUnit.config.autorun = false;
+//TODO: Use a proper test framework?
+var done = new Promise(function (resolve) {
+    QUnit.done(function () {
+        resolve();
+    });
+});
 
-require("./qunit/tests.js");
 var qunitRunner = new JsReporters.QUnitAdapter();
 var qunitTestReporter = new JsReporters.TestReporter(qunitRunner, referenceData.QUnit);
 
+QUnit.config.autorun = false;
+
+require("./qunit/tests.js");
+
 QUnit.load();
+
+done.then(function () {
+    process.exit(qunitTestReporter.ok ? 0 : 1);
+});


### PR DESCRIPTION
This PR does the following:
- add `runStart`, `suiteStart`, `testStart` events
- refactor `JasmineAdapter` to emit start events during runtime
- refactor `QUnitAdapter` to emit start events during runtime
- adjust tests

Open issues: 
- Jasmine catches exceptions in `afterAll` hooks  and exposes them as `failedExpectations` on a suite. (How) do we want to handle this?
