### PR TITLE
Fix Build

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,17 +1,17 @@
 var mkdirp = require("mkdirp");
-var esperanto = require("esperanto");
+var rollup = require("rollup");
 var fs = require("fs");
 var babel = require("babel");
 var pkg = require("./package.json");
 
 mkdirp.sync("dist");
 
-esperanto.bundle({
-    base: "lib",
-    entry: "index.js"
+rollup.rollup({
+    entry: "lib/index.js"
 }).then(function (bundle) {
-    var umd = bundle.toUmd({
-        name: "JsReporters"
+    var umd = bundle.generate({
+        format: "umd",
+        moduleName: "JsReporters"
     });
 
     var transformed = babel.transform(umd.code, {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "babel": "^5.6.14",
     "commitplease": "^2.2.3",
     "eslint": "^0.24.1",
-    "esperanto": "^0.7.3",
     "jasmine": "^2.3.1",
     "jasmine-core": "^2.3.4",
     "mkdirp": "^0.5.1",
-    "qunitjs": "^1.18.0"
+    "qunitjs": "^1.18.0",
+    "rollup": "^0.19.1"
   },
   "eslintConfig": {
     "env": {

--- a/test/qunit/tests.js
+++ b/test/qunit/tests.js
@@ -1,4 +1,10 @@
-/*global QUnit*/
+/*eslint-disable no-use-before-define*/
+if(typeof QUnit === "undefined") {
+	var QUnit = require("qunitjs");
+}
+
+/*eslint-enable no-use-before-define*/
+
 QUnit.module("group a");
 QUnit.test("foo", function (assert) {
     assert.equal(5, "5");


### PR DESCRIPTION
Esperanto is now deprecated:
```
> node build.js
[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)
[DEPRECATION NOTICE] Esperanto is no longer under active development. To bundle ES6 modules, consider using Rollup (https://github.com/rollup/rollup). See https://github.com/rollup/rollup/wiki/Migrating-from-Esperanto for help migrating
```
They pushed this as a patch release which broke our build script. :disappointed: 
Also, there is an issue with QUnit which now requires an expicit import in the test file. 