### PR TITLE
One reference data object for all adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "jasmine": "^2.3.1",
     "jasmine-core": "^2.3.4",
     "mocha": "^2.4.5",
-    "qunitjs": "^1.18.0",
+    "qunitjs": "^2.0.0-rc1",
     "rollup": "^0.26.0",
     "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-commonjs": "^2.2.1",

--- a/test/fixtures/jasmine.js
+++ b/test/fixtures/jasmine.js
@@ -1,0 +1,49 @@
+/* global describe, it, xit */
+
+it('global test', function () {
+
+})
+
+describe('suite with passing test', function () {
+  it('should pass', function () {
+
+  })
+})
+
+describe('suite with skipped test', function () {
+  xit('should skip', function () {
+
+  })
+})
+
+describe('suite with failing test', function () {
+  it('should fail', function () {
+    throw new Error('error')
+  })
+})
+
+describe('suite with tests', function () {
+  it('should pass', function () {
+
+  })
+
+  xit('should skip', function () {
+
+  })
+
+  it('should fail', function () {
+    throw new Error('error')
+  })
+})
+
+describe('outter suite', function () {
+  describe('inner suite', function () {
+    it('inner test', function () {
+
+    })
+  })
+
+  it('outter test', function () {
+
+  })
+})

--- a/test/fixtures/mocha.js
+++ b/test/fixtures/mocha.js
@@ -1,0 +1,49 @@
+/* global describe, it */
+
+it('global test', function () {
+
+})
+
+describe('suite with passing test', function () {
+  it('should pass', function () {
+
+  })
+})
+
+describe('suite with skipped test', function () {
+  it.skip('should skip', function () {
+
+  })
+})
+
+describe('suite with failing test', function () {
+  it('should fail', function () {
+    throw new Error('error')
+  })
+})
+
+describe('suite with tests', function () {
+  it('should pass', function () {
+
+  })
+
+  it.skip('should skip', function () {
+
+  })
+
+  it('should fail', function () {
+    throw new Error('error')
+  })
+})
+
+describe('outter suite', function () {
+  describe('inner suite', function () {
+    it('inner test', function () {
+
+    })
+  })
+
+  it('outter test', function () {
+
+  })
+})

--- a/test/fixtures/qunit.js
+++ b/test/fixtures/qunit.js
@@ -1,0 +1,43 @@
+var QUnit = require('qunitjs')
+
+QUnit.test('global test', function () {
+
+})
+
+QUnit.module('suite with passing test')
+QUnit.test('should pass', function () {
+
+})
+
+QUnit.module('suite with skipped test')
+QUnit.skip('should skip', function () {
+
+})
+
+QUnit.module('suite with failing test')
+QUnit.test('should fail', function () {
+  throw new Error('error')
+})
+
+QUnit.module('suite with tests')
+QUnit.test('should pass', function () {
+
+})
+QUnit.skip('should skip', function () {
+
+})
+QUnit.test('should fail', function () {
+  throw new Error('error')
+})
+
+QUnit.module('outter suite', function () {
+  QUnit.module('inner suite', function () {
+    QUnit.test('inner test', function () {
+
+    })
+  })
+
+  QUnit.test('outter test', function () {
+
+  })
+})

--- a/test/integration/adapters-run.js
+++ b/test/integration/adapters-run.js
@@ -4,8 +4,7 @@ var Mocha = require('mocha')
 var JsReporters = require('../../dist/js-reporters.js')
 var path = require('path')
 
-var testDir = path.join(__dirname, '..')
-var testFile = 'tests.js'
+var testDir = path.join(__dirname, '../fixtures')
 
 /**
  * Exports a function for each adapter that will run
@@ -17,8 +16,8 @@ module.exports = {
     var jasmineRunner
 
     jasmine.loadConfig({
-      spec_dir: 'test/jasmine',
-      spec_files: [testFile]
+      spec_dir: 'test/fixtures',
+      spec_files: ['jasmine.js']
     })
 
     jasmineRunner = new JsReporters.JasmineAdapter(jasmine.env)
@@ -36,7 +35,7 @@ module.exports = {
 
     QUnit.config.autorun = false
 
-    require(path.join(testDir, 'qunit', testFile))
+    require(path.join(testDir, 'qunit.js'))
 
     QUnit.load()
   },
@@ -45,7 +44,7 @@ module.exports = {
     var mocha = new Mocha()
     var mochaRunner
 
-    mocha.addFile(path.join(testDir, 'mocha', testFile))
+    mocha.addFile(path.join(testDir, 'mocha.js'))
 
     mochaRunner = new JsReporters.MochaAdapter(mocha)
 

--- a/test/integration/adapters.js
+++ b/test/integration/adapters.js
@@ -1,15 +1,14 @@
 /* eslint-env mocha */
 
 var expect = require('chai').expect
-var data = require('../referenceData')
+var refData = require('./reference-data.js')
 var runAdapters = require('./adapters-run.js')
 
 // Collecting the adapter's output.
-var collectedData = {}
+var collectedData
 
 function _collectOutput (eventName, done, eventData) {
-  // Assume now (for simplicity) that there is only one event per type.
-  collectedData[eventName] = eventData
+  collectedData.push([eventName, eventData])
   done()
 }
 
@@ -30,20 +29,19 @@ function _attachListeners (done, runner) {
 describe('Adapters integration', function () {
   Object.keys(runAdapters).forEach(function (adapter) {
     describe(adapter + ' adapter', function () {
-      var referenceData = data[adapter]
+      var testDescription
 
       before(function (done) {
-        collectedData = {}
+        collectedData = []
         runAdapters[adapter](_attachListeners.bind(null, done))
       })
 
-      describe('Global suite', function () {
-        it('should have no name', function () {
-          expect(referenceData[0][1].name).to.be.equal(collectedData.runStart.name)
-        })
+      refData.forEach(function (value, index) {
+        testDescription = value[2]
 
-        it('should have all the other suites as childSuites', function () {
-          expect(referenceData[0][1].childSuites).to.have.lengthOf(collectedData.runStart.childSuites.length)
+        it(testDescription, function () {
+          expect(collectedData[index][0]).equal(value[0])
+          expect(collectedData[index][1]).to.be.deep.equal(value[1])
         })
       })
     })

--- a/test/integration/adapters.js
+++ b/test/integration/adapters.js
@@ -28,7 +28,7 @@ function _attachListeners (done, runner) {
 
 describe('Adapters integration', function () {
   Object.keys(runAdapters).forEach(function (adapter) {
-    describe(adapter + ' adapter', function () {
+    describe.skip(adapter + ' adapter', function () {
       var testDescription
 
       before(function (done) {

--- a/test/integration/reference-data.js
+++ b/test/integration/reference-data.js
@@ -1,0 +1,129 @@
+var JsReporters = require('../../dist/js-reporters.js')
+var Suite = JsReporters.Suite
+var Test = JsReporters.Test
+
+var globalTestStart = new Test('global test', undefined, undefined, undefined,
+    undefined)
+var globalTestEnd = new Test('global test', undefined, 'passed', 0, [])
+
+var passingTestStart1 = new Test('should pass', 'suite with passing test',
+    undefined, undefined, undefined)
+var passingTestEnd1 = new Test('should pass', 'suite with passing test',
+    'passed', 0, [])
+
+var passingTestStart2 = new Test('should pass', 'suite with tests',
+    undefined, undefined, undefined)
+var passingTestEnd2 = new Test('should pass', 'suite with tests', 'passed',
+    0, [])
+
+var skippedTestStart1 = new Test('should skip', 'suite with skipped test',
+    undefined, undefined, undefined)
+var skippedTestEnd1 = new Test('should skip', 'suite with skipped test',
+    'skipped', undefined, [])
+
+var skippedTestStart2 = new Test('should skip', 'suite with tests',
+    undefined, undefined, undefined)
+var skippedTestEnd2 = new Test('should skip', 'suite with tests', 'skipped',
+    undefined, [])
+
+var failingTestStart1 = new Test('should fail', 'suite with failing test',
+    undefined, undefined, undefined)
+var failingTestEnd1 = new Test('should fail', 'suite with failing test', 'failed',
+    0, [new Error('error')])
+
+var failingTestStart2 = new Test('should fail', 'suite with tests',
+    undefined, undefined, undefined)
+var failingTestEnd2 = new Test('should fail', 'suite with tests', 'failed',
+    0, [new Error('error')])
+
+var innerTestStart = new Test('inner test', 'Inner suite',
+    undefined, undefined, undefined)
+var innerTestEnd = new Test('inner test', 'Inner suite', 'passed', 0, [])
+
+var outterTestStart = new Test('outter test', 'Outter suite',
+    undefined, undefined, undefined)
+var outterTestEnd = new Test('outter test', 'Outter suite', 'passed', 0, [])
+
+var passingSuiteStart = new Suite('suite with passing test', [],
+    [passingTestStart1])
+var passingSuiteEnd = new Suite('suite with passing test', [],
+    [passingTestEnd1])
+
+var skippedSuiteStart = new Suite('suite with skipped test', [],
+    [skippedTestStart1])
+var skippedSuiteEnd = new Suite('suite with skipped test', [],
+    [skippedTestEnd1])
+
+var failingSuiteStart = new Suite('suite with failing test', [],
+    [failingTestStart1])
+var failingSuiteEnd = new Suite('suite with failing test', [],
+    [failingTestEnd1])
+
+var testSuiteStart = new Suite('suite with tests', [], [
+  passingTestStart2,
+  skippedTestStart2,
+  failingTestStart2
+])
+var testSuiteEnd = new Suite('suite with tests', [], [
+  passingTestEnd2,
+  skippedTestEnd2,
+  failingTestEnd2
+])
+
+var innerSuiteStart = new Suite('inner suite', [], [innerTestStart])
+var innerSuiteEnd = new Suite('inner suite', [], [innerTestEnd])
+
+var outterSuiteStart = new Suite('outter suite', [innerSuiteStart],
+    [outterTestStart])
+var outterSuiteEnd = new Suite('outter suite', [innerSuiteEnd],
+    [outterTestEnd])
+
+var globalSuiteStart = new Suite(undefined, [
+  passingSuiteStart,
+  skippedSuiteStart,
+  failingSuiteStart,
+  testSuiteStart,
+  outterSuiteStart
+], [globalTestStart])
+var globalSuiteEnd = new Suite(undefined, [
+  passingSuiteEnd,
+  skippedSuiteEnd,
+  failingSuiteEnd,
+  testSuiteEnd,
+  outterSuiteEnd
+], [globalTestEnd])
+
+module.exports = [
+  ['runStart', globalSuiteStart, 'Global suite starts'],
+  ['testStart', globalTestStart, 'Global test starts'],
+  ['testEnd', globalTestEnd, 'Global test ends'],
+  ['suiteStart', passingSuiteStart, 'Suite with one passing test starts'],
+  ['testStart', passingTestStart1, 'Passing test starts'],
+  ['testEnd', passingTestEnd1, 'Passing test ends'],
+  ['suiteEnd', passingSuiteEnd, 'Suite with one passing test ends'],
+  ['suiteStart', skippedSuiteStart, 'Suite with one skipped test starts'],
+  ['testStart', skippedTestStart1, 'Skipped test starts'],
+  ['testEnd', skippedTestEnd1, 'Skipped test ends'],
+  ['suiteEnd', skippedSuiteEnd, 'Suite with one skipped test ends'],
+  ['suiteStart', failingSuiteStart, 'Suite with one failing tests'],
+  ['testStart', failingTestStart1, 'Failing test starts'],
+  ['testEnd', failingTestEnd1, 'Failing test ends'],
+  ['suiteEnd', failingSuiteEnd, 'Suite with one failing test ends'],
+  ['suiteStart', testSuiteStart, 'Suite with multiple tests starts'],
+  ['testStart', passingTestStart2, 'Passing test starts'],
+  ['testEnd', passingTestEnd2, 'Passing test ends'],
+  ['testStart', skippedTestStart2, 'Skipped test starts'],
+  ['testEnd', skippedTestEnd2, 'Skipped test ends'],
+  ['testStart', failingTestStart2, 'Failing test starts'],
+  ['testEnd', failingTestEnd2, 'Failing test ends'],
+  ['suiteEnd', testSuiteEnd, 'Suite with multiple tests ends'],
+  ['suiteStart', outterSuiteStart, 'Outter suite starts'],
+  ['testStart', outterTestStart, 'Outter test starts'],
+  ['testEnd', outterTestEnd, 'Outter test ends'],
+  ['suiteStart', innerSuiteStart, 'Inner suite starts'],
+  ['testStart', innerTestStart, 'Inner test starts'],
+  ['testEnd', innerTestEnd, 'Inner test ends'],
+  ['suiteEnd', innerSuiteEnd, 'Inner suite ends'],
+  ['suiteEnd', outterSuiteEnd, 'Outter suite ends'],
+  ['runEnd', globalSuiteEnd, 'Global suite ends']
+]


### PR DESCRIPTION
This should solve #47 .

I have built a new Mocha test fixture, as also I wrote some tests for it and some bugs are already emerging (some tests are failing).

I would have also add a **global test**, a test with is not wrapped into a suite, this test would arrive into the global suite, Mocha and Qunit permit this, but **Jasmine no**, so I didn't included it, I will think to something to add it in the future.

I'm waiting your feedback @jzaefferer, to know if I can go further. Thanks!