### PR TITLE
Standardize tests run time to match with the reference data

### DIFF
--- a/test/integration/adapters.js
+++ b/test/integration/adapters.js
@@ -36,10 +36,24 @@ describe('Adapters integration', function () {
         runAdapters[adapter](_attachListeners.bind(null, done))
       })
 
+      it('tests runtime should be between 0 and 1 ms', function () {
+        collectedData.forEach(function (value) {
+          if (value[0] === 'testEnd' && value[1].status !== 'skipped') {
+            expect(value[1].runtime).to.be.within(0, 1)
+          }
+        })
+      })
+
       refData.forEach(function (value, index) {
         testDescription = value[2]
 
         it(testDescription, function () {
+          // Set tests runtime to 0 to match the reference tests runtime.
+          if (collectedData[index][0] === 'testEnd' &&
+              collectedData[index][1].status !== 'skipped') {
+            collectedData[index][1].runtime = 0
+          }
+
           expect(collectedData[index][0]).equal(value[0])
           expect(collectedData[index][1]).to.be.deep.equal(value[1])
         })


### PR DESCRIPTION
@jzaefferer I would like to take care on this pr of the `tests runtime`. In the ref data file the runtime is 0, Mocha runs them in 0 milliseconds, but it can happen that it will run them in 1 milliseconds (I think that it cannot take more than this, because there are simple tests, some of them also void). As a solution, I think to write one test that checks that all `test's run times` are in the range `0 - 1 milliseconds`, and then put all run times on 0 for the deep equal check.