### PR TITLE
Tokenize QUnit suites names after " > "

### DIFF
--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -89,16 +89,14 @@ export default class QUnitAdapter extends EventEmitter {
     // If a suite does not have a composed name, add it to the topLevelSuites,
     // this means that this suite is the direct child of the global suite.
     for (let suite of suites) {
-      let indexEnd = suite.name.lastIndexOf('>')
+      let indexEnd = suite.name.lastIndexOf(' > ')
 
       if (indexEnd !== -1) {
-        // Escape the '>' character and the space before it.
-        indexEnd = indexEnd - 1
-        // Find the '>' character that appears before the parent name.
-        let indexStart = suite.name.substring(0, indexEnd).lastIndexOf('>')
-        // If it is -1, the parent suite name starts at 0, else escape the
-        // '>' character and the space after it.
-        indexStart = (indexStart === -1) ? 0 : indexStart + 2
+        // Find the ' > ' characters that appears before the parent name.
+        let indexStart = suite.name.substring(0, indexEnd).lastIndexOf(' > ')
+        // If it is -1, the parent suite name starts at 0, else escape
+        // this characters ' > '.
+        indexStart = (indexStart === -1) ? 0 : indexStart + 3
 
         var parentSuiteName = suite.name.substring(indexStart, indexEnd)
 


### PR DESCRIPTION
Update tokenzing based on the discussion on the [browserstack-runner](https://github.com/browserstack/browserstack-runner/issues/157) repo.