### PR TITLE
Fix QUnit adapter

### DIFF
--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -85,7 +85,7 @@ export default class QUnitAdapter extends EventEmitter {
 
       modules = this.QUnit.config.modules.slice(1)
     } else {
-      globalSuite = new Suite(undefined, [], [])
+      globalSuite = new Suite(undefined, [], [], [])
       modules = this.QUnit.config.modules
     }
 


### PR DESCRIPTION
This fixes the Suite instantiation when there is [no global module](https://github.com/js-reporters/js-reporters/blob/31a233ed49a9a11f02a12c5a0fd84a71aaec4537/lib/adapters/QUnitAdapter.js#L88).