### PR TITLE
Remove dependency on es2015-rollup preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["es2015-rollup"]
+  "presets": [
+    ["es2015", {
+      "modules": false
+    }]
+  ],
+  "plugins": ["external-helpers"]
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test-versions": "mocha test/versions/versions.js"
   },
   "devDependencies": {
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-plugin-external-helpers": "^6.8.0",
+    "babel-preset-es2015": "^6.13.2",
     "chai": "^3.5.0",
     "chalk": "^1.1.3",
     "commitplease": "^2.2.3",


### PR DESCRIPTION
This fixes the bundling according to the updates of [babel](https://github.com/babel/babel/blob/master/CHANGELOG.md#loose-and-modules-options-for-babel-preset-es2015-3331-3627).