### PR TITLE
Fix reporter adding in Jasmine adapter

### DIFF
--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -10,17 +10,27 @@ export default class JasmineAdapter extends EventEmitter {
     super()
 
     this.jasmine = jasmine
+    // NodeJS/browser
+    this.env = jasmine.env || jasmine.getEnv()
     this.suites = {}
     this.tests = {}
 
-    jasmine.addReporter({
+    var reporter = {
       jasmineStarted: this.onJasmineStarted.bind(this),
       specDone: this.onSpecDone.bind(this),
       specStarted: this.onSpecStarted.bind(this),
       suiteStarted: this.onSuiteStarted.bind(this),
       suiteDone: this.onSuiteDone.bind(this),
       jasmineDone: this.onJasmineDone.bind(this)
-    })
+    }
+
+    // For NodeJS env use the "addReporter" function from the node package.
+    if (this.jasmine.addReporter) {
+      this.jasmine.addReporter(reporter)
+    } else {
+      // For browser env use the "addReporter" function from the jasmine-core.
+      this.env.addReporter(reporter)
+    }
   }
 
   createSuiteStart (suite) {
@@ -86,7 +96,7 @@ export default class JasmineAdapter extends EventEmitter {
 
   /**
    * Jasmine provides details about childSuites and tests only in the structure
-   * returned by "this.jasmine.topSuite()".
+   * returned by "this.env.topSuite()".
    *
    * This function creates the global suite for the runStart event, as also
    * saves the created suites and tests compliant with the CRI standard in an
@@ -130,7 +140,7 @@ export default class JasmineAdapter extends EventEmitter {
   }
 
   onJasmineStarted () {
-    this.globalSuite = this.createGlobalSuite(this.jasmine.topSuite(), [])
+    this.globalSuite = this.createGlobalSuite(this.env.topSuite(), [])
     this.emit('runStart', this.createSuiteStart(this.globalSuite))
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chalk": "^1.1.3",
     "commitplease": "^2.2.3",
     "events": "^1.1.0",
-    "jasmine": "^2.3.1",
+    "jasmine": "2.4.1",
     "mocha": "^2.4.5",
     "qunitjs": "^2.0.0-rc1",
     "rollup": "^0.34.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "commitplease": "^2.2.3",
     "events": "^1.1.0",
     "jasmine": "^2.3.1",
-    "jasmine-core": "^2.3.4",
     "mocha": "^2.4.5",
     "qunitjs": "^2.0.0-rc1",
     "rollup": "^0.34.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chalk": "^1.1.3",
     "commitplease": "^2.2.3",
     "events": "^1.1.0",
-    "jasmine": "2.4.1",
+    "jasmine": "^2.5.1",
     "mocha": "^2.4.5",
     "qunitjs": "^2.0.0-rc1",
     "rollup": "^0.34.1",

--- a/test/integration/adapters-run.js
+++ b/test/integration/adapters-run.js
@@ -20,8 +20,7 @@ module.exports = {
       spec_files: ['jasmine.js']
     })
 
-    jasmineRunner = new JsReporters.JasmineAdapter(jasmine.env)
-    jasmine.addReporter({})
+    jasmineRunner = new JsReporters.JasmineAdapter(jasmine)
 
     attachListeners(jasmineRunner)
 

--- a/test/versions/failing-versions.js
+++ b/test/versions/failing-versions.js
@@ -1,9 +1,12 @@
 /**
  * Here is a brief list with the known issues.
  *
- * Jasmine 2.3.0: the Jasmine adapter is working, something happens during
- * testing with our testing framework Mocha, which is receiving SIGINT and aborts its runner,
- * it may be a problem with the testing not with the adapter itself.
+ * Jasmine 2.3.0: there is a bug that makes Jasmine to exit and kill the
+ * process. This is solved in the 2.3.1 version. @see
+ * https://github.com/jasmine/jasmine-npm/blob/master/release_notes/2.3.1.md
+ *
+ * Jasmine 2.5.0: it is the same bug as in the 2.3.0 version. @see
+ * https://github.com/jasmine/jasmine-npm/issues/88
  *
  * Mocha 2.5.0: is not working because of a missing dependency, this is Mocha's
  * fault @see
@@ -13,7 +16,7 @@
 module.exports = {
   'qunitjs': ['1.9.0', '1.10.0', '1.11.0', '1.12.0-pre', '1.12.0', '1.13.0',
     '1.14.0', '1.15.0', '1.16.0', '1.17.0', '1.17.1', '1.18.0', '1.19.0'],
-  'jasmine': ['2.3.0'],
+  'jasmine': ['2.3.0', '2.5.0'],
   'mocha': ['0.3.0', '0.3.1', '0.3.2', '0.3.3', '0.3.4', '0.3.6', '0.4.0',
     '0.5.0', '0.6.0', '0.7.0', '0.7.1', '0.8.0', '0.9.0', '0.10.0', '0.10.1',
     '0.10.2', '0.11.0', '0.12.0', '0.12.1', '0.13.0', '0.14.0', '0.14.1',


### PR DESCRIPTION
This solves the adding of the jasmine adapter in a node env.

We cannot pass the `jasmine.env` to the reporter, we must pass in the `jasmine` object, which is a NodeJS helper over `jasmine-core`. We must use the `jasmine.addReporter` and **not** directly `jasmine.env.addReporter`, because then it will enter on this [branch](https://github.com/jasmine/jasmine-npm/blob/164b799c6e531f29b23722cf6975dfe1400ac7b6/lib/jasmine.js#L163) and jasmine will exit and kill the process. Using the `jasmine.addReporter` has some internal logic that holds from exiting.

Now the adapter has some extra logic to differentiate btw a node env and a browser env. Unfortunately we cannot test the browser part, because currently the tests are running only in a node env.