### PR TITLE
Specify data for Todo tests

### DIFF
--- a/lib/Data.js
+++ b/lib/Data.js
@@ -20,6 +20,7 @@ function getStatus (suite) {
   var passed = 0
   var failed = 0
   var skipped = 0
+  var todo = 0
   var tests = getAllTests(suite)
 
   for (let i = 0; i < tests.length; i++) {
@@ -33,6 +34,8 @@ function getStatus (suite) {
       passed++
     } else if (test.status === 'skipped') {
       skipped++
+    } else if (test.status === 'todo') {
+      todo++
     } else {
       failed++
     }
@@ -42,6 +45,8 @@ function getStatus (suite) {
     return 'failed'
   } else if (skipped > 0 && passed === 0) {
     return 'skipped'
+  } else if (todo > 0 && passed === 0) {
+    return 'todo'
   } else {
     return 'passed'
   }
@@ -62,6 +67,7 @@ function getSuiteEndTestCounts (suite) {
     passed: tests.filter((test) => test.status === 'passed').length,
     failed: tests.filter((test) => test.status === 'failed').length,
     skipped: tests.filter((test) => test.status === 'skipped').length,
+    todo: tests.filter((test) => test.status === 'todo').length,
     total: tests.length
   }
 }
@@ -73,13 +79,15 @@ export class Assertion {
    * @param {*} expected
    * @param {String} message
    * @param {String|undefined} stack
+   * @param {Boolean} todo
    */
-  constructor (passed, actual, expected, message, stack) {
+  constructor (passed, actual, expected, message, stack, todo) {
     this.passed = passed
     this.actual = actual
     this.expected = expected
     this.message = message
     this.stack = stack
+    this.todo = todo
   }
 }
 

--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -18,25 +18,31 @@ export default class TapReporter {
   onTestEnd (test) {
     this.testCount = this.testCount + 1
 
-    // TODO maybe switch to test.fullName
-    // @see https://github.com/js-reporters/js-reporters/issues/65
     if (test.status === 'passed') {
-      console.log(`ok ${this.testCount} ${test.name}`)
+      console.log(`ok ${this.testCount} ${test.fullName.join(' > ')}`)
     } else if (test.status === 'skipped') {
-      console.log(`ok ${this.testCount} ${test.name} # SKIP`)
+      console.log(`ok ${this.testCount} # SKIP ${test.fullName.join(' > ')}`)
+    } else if (test.status === 'todo') {
+      console.log(`not ok ${this.testCount} # TODO ${test.fullName.join(' > ')}`)
     } else {
-      console.log(`not ok ${this.testCount} ${test.name}`)
+      console.log(`not ok ${this.testCount} ${test.fullName.join(' > ')}`)
 
       test.errors.forEach(function (error) {
         console.log('  ---')
-        console.log(`  message: "${error.toString()}"`)
+        console.log(`  message: "${error.message}"`)
         console.log('  severity: failed')
+        console.log(`  stack: "${error.stack}"`)
         console.log('  ...')
       })
     }
   }
 
   onRunEnd (globalSuite) {
-    console.log(`1..${this.testCount}`)
+    console.log(`1..${globalSuite.testCounts.total}`)
+    console.log(`tests ${globalSuite.testCounts.total}`)
+    console.log(`pass ${globalSuite.testCounts.pass}`)
+    console.log(`fail ${globalSuite.testCounts.fail}`)
+    console.log(`skip ${globalSuite.testCounts.skip}`)
+    console.log(`todo ${globalSuite.testCounts.todo}`)
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rollup-plugin-node-resolve": "^1.7.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
-    "standard": "^6.0.8"
+    "standard": "^6.0.8",
+    "webpack": "^1.0.0"
   }
 }

--- a/test/integration/adapters.js
+++ b/test/integration/adapters.js
@@ -145,6 +145,7 @@ function getTestCountsEnd (refSuite) {
     passed: 0,
     failed: 0,
     skipped: 0,
+    todo: 0,
     total: refSuite.tests.length
   }
 
@@ -160,12 +161,17 @@ function getTestCountsEnd (refSuite) {
     return test.status === 'skipped'
   }).length
 
+  testCounts.todo += refSuite.tests.filter(function (test) {
+    return test.status === 'todo'
+  }).length
+
   refSuite.childSuites.forEach(function (childSuite) {
     var childTestCounts = getTestCountsEnd(childSuite)
 
     testCounts.passed += childTestCounts.passed
     testCounts.failed += childTestCounts.failed
     testCounts.skipped += childTestCounts.skipped
+    testCounts.todo += childTestCounts.todo
     testCounts.total += childTestCounts.total
   })
 
@@ -175,7 +181,7 @@ function getTestCountsEnd (refSuite) {
 describe('Adapters integration', function () {
   Object.keys(runAdapters).forEach(function (adapter) {
     describe(adapter + ' adapter', function () {
-      var keys = ['passed', 'actual', 'expected', 'message', 'stack']
+      var keys = ['passed', 'actual', 'expected', 'message', 'stack', 'todo']
 
       before(function (done) {
         collectedData = []

--- a/test/integration/reference-data.js
+++ b/test/integration/reference-data.js
@@ -17,7 +17,8 @@ var errors = [{
   actual: undefined,
   expected: undefined,
   message: undefined,
-  stack: undefined
+  stack: undefined,
+  todo: undefined
 }]
 
 var failedAssertions = [{
@@ -25,7 +26,8 @@ var failedAssertions = [{
   actual: undefined,
   expected: undefined,
   message: undefined,
-  stack: undefined
+  stack: undefined,
+  todo: undefined
 }]
 
 var passedAssertions = [{
@@ -33,7 +35,8 @@ var passedAssertions = [{
   actual: undefined,
   expected: undefined,
   message: undefined,
-  stack: undefined
+  stack: undefined,
+  todo: undefined
 }]
 
 var globalTestStart = new TestStart('global test', undefined, ['global test'])

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -9,6 +9,7 @@ module.exports = {
     new Error('first error'), new Error('second error')
   ]),
   skippedTest: new TestEnd('skip', undefined, [], 'skipped', 0, []),
+  todoTest: new TestEnd('todo', undefined, [], 'todo', 0, []),
   startSuite: new SuiteStart('start', 'start', [], []),
   startTest: new TestStart('start', 'start', 'start start'),
   endTest: new TestEnd('end', 'end', 'end end', 'failed', 0,

--- a/test/unit/tap-reporter.js
+++ b/test/unit/tap-reporter.js
@@ -27,7 +27,7 @@ describe('Tap reporter', function () {
 
   it('should output ok for a passing test', sinon.test(function () {
     var spy = this.stub(console, 'log')
-    var expected = 'ok 1 ' + data.passingTest.name
+    var expected = 'ok 1 ' + data.passingTest.fullName.join(' > ')
 
     emitter.emit('testEnd', data.passingTest)
 
@@ -36,16 +36,25 @@ describe('Tap reporter', function () {
 
   it('should output ok for a skipped test', sinon.test(function () {
     var spy = this.stub(console, 'log')
-    var expected = 'ok 2 ' + data.skippedTest.name + ' # SKIP'
+    var expected = 'ok 2 # SKIP ' + data.skippedTest.fullName.join(' > ')
 
     emitter.emit('testEnd', data.skippedTest)
 
     expect(spy).to.have.been.calledWith(expected)
   }))
 
+  it('should output not ok for a todo test', sinon.test(function () {
+    var spy = this.stub(console, 'log')
+    var expected = 'not ok 3 # TODO ' + data.todoTest.fullName.join(' > ')
+
+    emitter.emit('testEnd', data.todoTest)
+
+    expect(spy).to.have.been.calledWith(expected)
+  }))
+
   it('should output not ok for a failing test', sinon.test(function () {
     var spy = this.stub(console, 'log')
-    var expected = 'not ok 3 ' + data.failingTest.name
+    var expected = 'not ok 4 ' + data.failingTest.fullName.join(' > ')
 
     emitter.emit('testEnd', data.failingTest)
 
@@ -58,8 +67,9 @@ describe('Tap reporter', function () {
 
     data.failingTest.errors.forEach(function (error) {
       expected.push('  ---')
-      expected.push('  message: "' + error.toString() + '"')
+      expected.push('  message: "' + error.message + '"')
       expected.push('  severity: failed')
+      expected.push('  stack: "' + error.stack + '"')
       expected.push('  ...')
     })
 
@@ -72,10 +82,28 @@ describe('Tap reporter', function () {
 
   it('should output the total number of tests', sinon.test(function () {
     var spy = this.stub(console, 'log')
-    var expected = '1..4'
+    var summary = '1..6'
+    var testCount = 'tests 6'
+    var passCount = 'pass 3'
+    var failCount = 'fail 2'
+    var skipCount = 'skip 1'
+    var todoCount = 'todo 0'
 
-    emitter.emit('runEnd', {})
+    emitter.emit('runEnd', {
+      testCounts: {
+        total: 6,
+        pass: 3,
+        fail: 2,
+        skip: 1,
+        todo: 0
+      }
+    })
 
-    expect(spy).to.have.been.calledWith(expected)
+    expect(spy).to.have.been.calledWith(summary)
+    expect(spy).to.have.been.calledWith(testCount)
+    expect(spy).to.have.been.calledWith(passCount)
+    expect(spy).to.have.been.calledWith(failCount)
+    expect(spy).to.have.been.calledWith(skipCount)
+    expect(spy).to.have.been.calledWith(todoCount)
   }))
 })


### PR DESCRIPTION
This proposes adding a new status of `todo` for both Suites and Tests. It is similar to the `skipped` status in that it should be counted separately from `passed` tests, but is also different because it is possible that `todo` tests can also fail.

`todo` should represent tests where there is some amount of incomplete work, meaning that there is at least one failing assertion in the test. These assertions should still be reported as normal, but should not cause a `todo` test to fail. A `todo` only fails when all assertions have passed. In that case, the status should be reported as `failed` so that reporters can properly notify that the feature is now implemented.

_Original discussion occurred in https://github.com/qunitjs/qunit/pull/1006._

cc @leobalter