### PR TITLE
Reporter: Print "actual:", "expected:" even if they are undefined

### DIFF
--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -46,12 +46,14 @@ export default class TapReporter {
     console.log(`  message: "${error.message || 'failed'}"`)
     console.log(`  severity: ${severity || 'failed'}`)
 
-    if (error.actual) {
-      console.log(`  actual: ${JSON.stringify(error.actual, null, 2)}`)
+    if (error.hasOwnProperty('actual')) {
+      var actualStr = error.actual !== undefined ? JSON.stringify(error.actual, null, 2) : 'undefined'
+      console.log(`  actual: ${actualStr}`)
     }
 
-    if (error.expected) {
-      console.log(`  expected: ${JSON.stringify(error.expected, null, 2)}`)
+    if (error.hasOwnProperty('expected')) {
+      var expectedStr = error.expected !== undefined ? JSON.stringify(error.expected, null, 2) : 'undefined'
+      console.log(`  expected: ${expectedStr}`)
     }
 
     if (error.stack) {

--- a/test/unit/data.js
+++ b/test/unit/data.js
@@ -8,6 +8,26 @@ module.exports = {
   failingTest: new TestEnd('fail', undefined, [], 'failed', 0, [
     new Error('first error'), new Error('second error')
   ]),
+  actualUndefinedTest: new TestEnd('fail', undefined, [], 'failed', 0, [{
+    passed: false,
+    actual: undefined,
+    expected: 'expected'
+  }]),
+  actualFalsyTest: new TestEnd('fail', undefined, [], 'failed', 0, [{
+    passed: false,
+    actual: 0,
+    expected: 'expected'
+  }]),
+  expectedUndefinedTest: new TestEnd('fail', undefined, [], 'failed', 0, [{
+    passed: false,
+    actual: 'actual',
+    expected: undefined
+  }]),
+  expectedFalsyTest: new TestEnd('fail', undefined, [], 'failed', 0, [{
+    passed: false,
+    actual: 'actual',
+    expected: 0
+  }]),
   skippedTest: new TestEnd('skip', undefined, [], 'skipped', 0, []),
   todoTest: new TestEnd('todo', undefined, [], 'todo', 0, []),
   startSuite: new SuiteStart('start', 'start', [], []),

--- a/test/unit/tap-reporter.js
+++ b/test/unit/tap-reporter.js
@@ -81,6 +81,38 @@ describe('Tap reporter', function () {
     }
   }))
 
+  it('should output actual value for failed assertions even it was undefined', sinon.test(function () {
+    var spy = this.stub(console, 'log')
+
+    emitter.emit('testEnd', data.actualUndefinedTest)
+
+    expect(spy).to.have.been.calledWith('  actual: undefined')
+  }))
+
+  it('should output actual value for failed assertions even it was falsy', sinon.test(function () {
+    var spy = this.stub(console, 'log')
+
+    emitter.emit('testEnd', data.actualFalsyTest)
+
+    expect(spy).to.have.been.calledWith('  actual: 0')
+  }))
+
+  it('should output expected value for failed assertions even it was undefined', sinon.test(function () {
+    var spy = this.stub(console, 'log')
+
+    emitter.emit('testEnd', data.expectedUndefinedTest)
+
+    expect(spy).to.have.been.calledWith('  expected: undefined')
+  }))
+
+  it('should output expected value for failed assertions even it was falsy', sinon.test(function () {
+    var spy = this.stub(console, 'log')
+
+    emitter.emit('testEnd', data.expectedFalsyTest)
+
+    expect(spy).to.have.been.calledWith('  expected: 0')
+  }))
+
   it('should output the total number of tests', sinon.test(function () {
     var spy = this.stub(console, 'log')
     var summary = '1..6'

--- a/test/unit/tap-reporter.js
+++ b/test/unit/tap-reporter.js
@@ -76,8 +76,6 @@ describe('Tap reporter', function () {
 
     emitter.emit('testEnd', data.failingTest)
 
-    console.warn(expected)
-
     for (var i = 0; i < expected.length; i++) {
       expect(spy).to.have.been.calledWith(expected[i])
     }


### PR DESCRIPTION
If "foo" was expected but the actual value was undefined, then print:

  actual: undefined
  expected: "foo"

If undefined was expected but "foo" was returned, then we print:

  actual: "foo"
  expected: undefined

NOTE: When "actual" and "expected" are both undefined, the error
being logged is not one comparing two values, for example:

  message: "Too many calls to the `assert.async` callback"
  severity: failed