### PR TITLE
Reporter: TapReporter align actual with expected.

### DIFF
--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -48,7 +48,7 @@ export default class TapReporter {
 
     if (error.hasOwnProperty('actual')) {
       var actualStr = error.actual !== undefined ? JSON.stringify(error.actual, null, 2) : 'undefined'
-      console.log(`  actual: ${actualStr}`)
+      console.log(`  actual  : ${actualStr}`)
     }
 
     if (error.hasOwnProperty('expected')) {

--- a/test/unit/tap-reporter.js
+++ b/test/unit/tap-reporter.js
@@ -86,7 +86,7 @@ describe('Tap reporter', function () {
 
     emitter.emit('testEnd', data.actualUndefinedTest)
 
-    expect(spy).to.have.been.calledWith('  actual: undefined')
+    expect(spy).to.have.been.calledWith('  actual  : undefined')
   }))
 
   it('should output actual value for failed assertions even it was falsy', sinon.test(function () {
@@ -94,7 +94,7 @@ describe('Tap reporter', function () {
 
     emitter.emit('testEnd', data.actualFalsyTest)
 
-    expect(spy).to.have.been.calledWith('  actual: 0')
+    expect(spy).to.have.been.calledWith('  actual  : 0')
   }))
 
   it('should output expected value for failed assertions even it was undefined', sinon.test(function () {


### PR DESCRIPTION
When comparing two strings, it is significantly easier to spot the difference when they are aligned. This change pads the label for `actual` with a couple of spaces so that the actual value is printed at the same indentation as the expected value. Previously the expected value was right shifted by 2 characters...

Before:

<img width="457" alt="2018-05-18_23-31-32_65aka_tmux image" src="https://user-images.githubusercontent.com/12637/40264527-d8961912-5af3-11e8-982f-d662bdd7b625.png">

After:

<img width="402" alt="2018-05-18_23-29-33_ogp95_tmux image" src="https://user-images.githubusercontent.com/12637/40264532-f1945974-5af3-11e8-865a-f330340f1bd0.png">
