### PR TITLE
Reporter: Fix YAML output in TAP reporter

### DIFF
--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -47,13 +47,13 @@ export default class TapReporter {
     console.log(`  severity: ${severity || 'failed'}`)
 
     if (error.hasOwnProperty('actual')) {
-      var actualStr = error.actual !== undefined ? JSON.stringify(error.actual, null, 2).replace(/"/g, '\\"').replace(/\n/g, '\\n') : 'undefined'
-      console.log(`  actual: "${actualStr}"`)
+      var actualStr = error.actual !== undefined ? ('"' + JSON.stringify(error.actual, null, 2).replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"') : 'undefined'
+      console.log(`  actual: ${actualStr}`)
     }
 
     if (error.hasOwnProperty('expected')) {
-      var expectedStr = error.expected !== undefined ? JSON.stringify(error.expected, null, 2).replace(/"/g, '\\"').replace(/\n/g, '\\n') : 'undefined'
-      console.log(`  expected: "${expectedStr}"`)
+      var expectedStr = error.expected !== undefined ? ('"' + JSON.stringify(error.expected, null, 2).replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"') : 'undefined'
+      console.log(`  expected: ${expectedStr}`)
     }
 
     if (error.stack) {

--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -47,13 +47,13 @@ export default class TapReporter {
     console.log(`  severity: ${severity || 'failed'}`)
 
     if (error.hasOwnProperty('actual')) {
-      var actualStr = error.actual !== undefined ? JSON.stringify(error.actual, null, 2) : 'undefined'
-      console.log(`  actual: ${actualStr}`)
+      var actualStr = error.actual !== undefined ? JSON.stringify(error.actual, null, 2).replace(/"/g, '\\"').replace(/\n/g, '\\n') : 'undefined'
+      console.log(`  actual: "${actualStr}"`)
     }
 
     if (error.hasOwnProperty('expected')) {
-      var expectedStr = error.expected !== undefined ? JSON.stringify(error.expected, null, 2) : 'undefined'
-      console.log(`  expected: ${expectedStr}`)
+      var expectedStr = error.expected !== undefined ? JSON.stringify(error.expected, null, 2).replace(/"/g, '\\"').replace(/\n/g, '\\n') : 'undefined'
+      console.log(`  expected: "${expectedStr}"`)
     }
 
     if (error.stack) {

--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -43,7 +43,7 @@ export default class TapReporter {
 
   logError (error, severity) {
     console.log('  ---')
-    console.log(`  message: "${error.message.replace (/"/g, '\\"') || 'failed'}"`)
+    console.log(`  message: "${error.message.replace(/"/g, '\\"') || 'failed'}"`)
     console.log(`  severity: ${severity || 'failed'}`)
 
     if (error.hasOwnProperty('actual')) {
@@ -57,7 +57,7 @@ export default class TapReporter {
     }
 
     if (error.stack) {
-      console.log(`  stack: "${error.stack.replace (/"/g, '\\"').replace (/\n/g, "\\n")}"`)
+      console.log(`  stack: "${error.stack.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`)
     }
 
     console.log('  ...')

--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -43,7 +43,7 @@ export default class TapReporter {
 
   logError (error, severity) {
     console.log('  ---')
-    console.log(`  message: "${error.message || 'failed'}"`)
+    console.log(`  message: "${error.message.replace (/"/g, '\\"') || 'failed'}"`)
     console.log(`  severity: ${severity || 'failed'}`)
 
     if (error.hasOwnProperty('actual')) {
@@ -57,7 +57,7 @@ export default class TapReporter {
     }
 
     if (error.stack) {
-      console.log(`  stack: ${error.stack}`)
+      console.log(`  stack: "${error.stack.replace (/"/g, '\\"').replace (/\n/g, "\\n")}"`)
     }
 
     console.log('  ...')

--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -43,7 +43,7 @@ export default class TapReporter {
 
   logError (error, severity) {
     console.log('  ---')
-    console.log(`  message: "${error.message.replace(/"/g, '\\"') || 'failed'}"`)
+    console.log(`  message: "${(error.message || 'failed').replace(/"/g, '\\"')}"`)
     console.log(`  severity: ${severity || 'failed'}`)
 
     if (error.hasOwnProperty('actual')) {

--- a/test/unit/tap-reporter.js
+++ b/test/unit/tap-reporter.js
@@ -68,14 +68,13 @@ describe('Tap reporter', function () {
 
     data.failingTest.errors.forEach(function (error) {
       expected.push('  ---')
-      expected.push('  message: "' + error.message + '"')
+      expected.push('  message: "' + error.message.replace(/"/g, '\\"') + '"')
       expected.push('  severity: failed')
-      expected.push('  stack: ' + error.stack)
+      expected.push('  stack: "' + error.stack.replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"')
       expected.push('  ...')
     })
 
     emitter.emit('testEnd', data.failingTest)
-
     for (var i = 0; i < expected.length; i++) {
       expect(spy).to.have.been.calledWith(expected[i])
     }
@@ -94,7 +93,7 @@ describe('Tap reporter', function () {
 
     emitter.emit('testEnd', data.actualFalsyTest)
 
-    expect(spy).to.have.been.calledWith('  actual: 0')
+    expect(spy).to.have.been.calledWith('  actual: "0"')
   }))
 
   it('should output expected value for failed assertions even it was undefined', sinon.test(function () {
@@ -110,7 +109,7 @@ describe('Tap reporter', function () {
 
     emitter.emit('testEnd', data.expectedFalsyTest)
 
-    expect(spy).to.have.been.calledWith('  expected: 0')
+    expect(spy).to.have.been.calledWith('  expected: "0"')
   }))
 
   it('should output the total number of tests', sinon.test(function () {


### PR DESCRIPTION
When a message or stack trace contains double quotes, or when the stack
trace contains more than one line, we escape the values.

Fixes #109