### PR TITLE
Spec: Remove "todo" from Assertion event data

### DIFF
--- a/lib/Data.js
+++ b/lib/Data.js
@@ -79,15 +79,13 @@ class Assertion {
    * @param {*} expected
    * @param {String} message
    * @param {String|undefined} stack
-   * @param {Boolean} todo
    */
-  constructor (passed, actual, expected, message, stack, todo) {
+  constructor (passed, actual, expected, message, stack) {
     this.passed = passed;
     this.actual = actual;
     this.expected = expected;
     this.message = message;
     this.stack = stack;
-    this.todo = todo;
   }
 }
 

--- a/spec/cri-draft.adoc
+++ b/spec/cri-draft.adoc
@@ -254,7 +254,6 @@ The **Assertion** object contains information about a single <<assertion>>.
 * `Mixed` **expected**: The expected value passed to the assertion, should be similar to `actual` for passed assertions.
 * `string` **message**: Name of the actual value, or description of what the assertion validates.
 * `string|undefined` **stack**: Optional stack trace. For a "passed" assertion, it is always `undefined`.
-* `boolean` **todo**: Whether this assertion was part of a todo test.
 
 It is allowed for additional non-standard properties to be added to am Assertion object, by the testing framework or a reporter.
 

--- a/test/integration/adapters.js
+++ b/test/integration/adapters.js
@@ -47,7 +47,7 @@ function normalizeTestEnd (test) {
     test.runtime = 42;
   }
 
-  // Only check the "passed" and any "todo" property.
+  // Only check the "passed" property.
   // Throw away the rest of the actual assertion objects as being framework-specific.
   if (test.assertions) {
     test.assertions.forEach(assertion => {

--- a/test/integration/reference-data.js
+++ b/test/integration/reference-data.js
@@ -3,8 +3,7 @@ const failedAssertion = {
   actual: undefined,
   expected: undefined,
   message: undefined,
-  stack: undefined,
-  todo: undefined
+  stack: undefined
 };
 
 const passedAssertion = {
@@ -12,8 +11,7 @@ const passedAssertion = {
   actual: undefined,
   expected: undefined,
   message: undefined,
-  stack: undefined,
-  todo: undefined
+  stack: undefined
 };
 
 const globalTestStart = {


### PR DESCRIPTION
* This is redundant with the information already available in
  in the TestEnd event data.

* We don't know of any testing frameworks that support flipping
  the "todo" status on a per-assertion basis, nor does that
  seem likely in the future as "Todo test" is defined as a test
  with one or more expected failures.

* Presence of this in the spec was a barrier to entry as it means
  common assertion exception objects would require being cloned,
  mutated, or otherwise mapped to set accordingly.

Fixes https://github.com/js-reporters/js-reporters/issues/105.