### PR TITLE
[BREAKING CHANGE] Spec: Use `null` instead of `undefined`

### DIFF
--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -44,7 +44,7 @@ module.exports = class JasmineAdapter extends EventEmitter {
       actual: expectation.actual,
       expected: expectation.expected,
       message: expectation.message,
-      stack: expectation.stack !== '' ? expectation.stack : undefined
+      stack: expectation.stack !== '' ? expectation.stack : null
     };
   }
 
@@ -59,7 +59,7 @@ module.exports = class JasmineAdapter extends EventEmitter {
       suiteName: testStart.suiteName,
       fullName: testStart.fullName.slice(),
       status: (result.status === 'pending') ? 'skipped' : result.status,
-      runtime: (result.status === 'pending') ? undefined : (new Date() - this.startTime),
+      runtime: (result.status === 'pending') ? null : (new Date() - this.startTime),
       errors,
       assertions
     };
@@ -74,7 +74,7 @@ module.exports = class JasmineAdapter extends EventEmitter {
   createSuiteStart (result, parentNames) {
     const isGlobalSuite = (result.description === 'Jasmine__TopLevel__Suite');
 
-    const name = isGlobalSuite ? undefined : result.description;
+    const name = isGlobalSuite ? null : result.description;
     const fullName = parentNames.slice();
     const tests = [];
     const childSuites = [];
@@ -130,9 +130,9 @@ module.exports = class JasmineAdapter extends EventEmitter {
       // Jasmine has result.status, but does not propagate 'todo' or 'skipped'
       status: helperData.status,
       testCounts: helperData.testCounts,
-      // Jasmine 3.4+ has result.duration, but uses 0 instead of undefined
+      // Jasmine 3.4+ has result.duration, but uses 0 instead of null
       // when 'skipped' is skipped.
-      runtime: helperData.status === 'skipped' ? undefined : (result.duration || helperData.runtime)
+      runtime: helperData.status === 'skipped' ? null : (result.duration || helperData.runtime)
     };
   }
 

--- a/lib/adapters/MochaAdapter.js
+++ b/lib/adapters/MochaAdapter.js
@@ -60,6 +60,7 @@ module.exports = class MochaAdapter extends EventEmitter {
       // Add also the test name.
       fullName.push(mochaTest.title);
     } else {
+      suiteName = null;
       fullName = [mochaTest.title];
     }
 
@@ -78,7 +79,7 @@ module.exports = class MochaAdapter extends EventEmitter {
         suiteName,
         fullName,
         status: (mochaTest.state === undefined) ? 'skipped' : mochaTest.state,
-        runtime: mochaTest.duration,
+        runtime: (mochaTest.duration === undefined) ? null : mochaTest.duration,
         errors,
         assertions: errors
       };
@@ -112,7 +113,7 @@ module.exports = class MochaAdapter extends EventEmitter {
 
   onStart () {
     const globalSuiteStart = this.convertToSuiteStart(this.runner.suite);
-    globalSuiteStart.name = undefined;
+    globalSuiteStart.name = null;
 
     this.emit('runStart', globalSuiteStart);
   }
@@ -158,7 +159,7 @@ module.exports = class MochaAdapter extends EventEmitter {
 
   onEnd () {
     const globalSuiteEnd = this.convertToSuiteEnd(this.runner.suite);
-    globalSuiteEnd.name = undefined;
+    globalSuiteEnd.name = null;
 
     this.emit('runEnd', globalSuiteEnd);
   }

--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -66,16 +66,16 @@ module.exports = class QUnitAdapter extends EventEmitter {
     if (this.QUnit.config.modules.length > 0 &&
         this.QUnit.config.modules[0].name === '') {
       globalSuite = this.createSuiteEnd(this.QUnit.config.modules[0]);
-      // The name of the global suite must be undefined.
-      globalSuite.name = undefined;
+      // The name of the global suite must be null.
+      globalSuite.name = null;
       globalSuite.tests.forEach((test) => {
-        test.suiteName = undefined;
+        test.suiteName = null;
       });
 
       modules = this.QUnit.config.modules.slice(1);
     } else {
       globalSuite = {
-        name: undefined,
+        name: null,
         fullName: [],
         tests: [],
         childSuites: [],
@@ -135,7 +135,7 @@ module.exports = class QUnitAdapter extends EventEmitter {
       actual: details.actual,
       expected: details.expected,
       message: details.message,
-      stack: details.source || undefined
+      stack: details.source || null
     };
     if (this.tests[details.testId]) {
       if (!details.result) {
@@ -156,11 +156,11 @@ module.exports = class QUnitAdapter extends EventEmitter {
       testEnd.status = 'passed';
     }
 
-    // QUnit uses 0 instead of undefined for runtime of skipped tests.
+    // QUnit uses 0 instead of null for runtime of skipped tests.
     if (!details.skipped) {
       testEnd.runtime = details.runtime;
     } else {
-      testEnd.runtime = undefined;
+      testEnd.runtime = null;
     }
   }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -33,7 +33,7 @@ function collectSuiteEndData (tests, childSuites) {
     status = 'passed';
   }
 
-  let runtime;
+  let runtime = null;
   if (status !== 'skipped') {
     runtime = all.reduce((sum, test) => {
       return sum + (test.status === 'skipped' ? 0 : test.runtime);

--- a/spec/cri-draft.adoc
+++ b/spec/cri-draft.adoc
@@ -185,7 +185,7 @@ A **SuiteStart** is a collection of TestStart and other SuiteStart objects.
 
 `SuiteStart` object:
 
-* `string|undefined` **name**: Name of the suite, or `undefined` for the `globalSuite`.
+* `string|null` **name**: Name of the suite, or `null` for the `globalSuite`.
 * `Array` **fullname**: List of strings containing the name of the suite and the names of all its ancestor suites.
 * `Array<TestStart>` **tests**: List of all tests that belong directly to the suite (not a child suite), as <<teststart>> objects.
 * `Array<SuiteStart>` **childSuites**: List of all direct child suites, as <<suitestart>> objects.
@@ -198,7 +198,7 @@ A **SuiteEnd** is a collection of TestEnd and other SuiteEnd objects, emitted af
 
 `SuiteEnd` object:
 
-* `string|undefined` **name**: Name of the suite, or `undefined` for the `globalSuite`.
+* `string|null` **name**: Name of the suite, or `null` for the `globalSuite`.
 * `Array` **fullname**: List of strings containing the name of the suite and the names of all its ancestor suites.
 * `Array<TestEnd>` **tests**: List of all tests that belong directly to the suite (not a child suite), as <<testend>> objects.
 * `Array<SuiteEnd>` **childSuites**: List of all direct child suites, as <<suiteend>> objects.
@@ -222,7 +222,7 @@ A **TestStart** holds basic information about a <<test>> as it is known before e
 `TestStart` object:
 
 * `string` **name**: Name of the test.
-* `string|undefined` **suiteName**: Name of the suite the test belongs to, or `undefined` for the `globalSuite`.
+* `string|null` **suiteName**: Name of the suite the test belongs to, or `null` for the `globalSuite`.
 * `Array<string>` **fullName**: List of strings containing the name of the test, and the names of all ancestor suites.
 
 === TestEnd
@@ -232,7 +232,7 @@ A **TestEnd** holds information about a <<test>> as captured after any execution
 `TestEnd` object:
 
 * `string` **name**: Name of the test.
-* `string|undefined` **suiteName**: Name of the suite the test belongs to, or `undefined` for the `globalSuite`.
+* `string|null` **suiteName**: Name of the suite the test belongs to, or `null` for the `globalSuite`.
 * `Array<string>` **fullName**: List of strings containing the name of the test, and the names of all ancestor suites.
 * `string` **status**: Result of the test, one of:
 ** **passed**, if all assertions have passed, or if no assertions were recorded.
@@ -253,7 +253,7 @@ The **Assertion** object contains information about a single <<assertion>>.
 * `Mixed` **actual**: The actual value passed to the assertion, should be similar to `expected` for passed assertions.
 * `Mixed` **expected**: The expected value passed to the assertion, should be similar to `actual` for passed assertions.
 * `string` **message**: Name of the actual value, or description of what the assertion validates.
-* `string|undefined` **stack**: Optional stack trace. For a "passed" assertion, it is always `undefined`.
+* `string|null` **stack**: Optional stack trace. For a "passed" assertion, the property must be set to `null`.
 
 It is allowed for additional non-standard properties to be added to am Assertion object, by the testing framework or a reporter.
 

--- a/test/integration/reference-data.js
+++ b/test/integration/reference-data.js
@@ -8,14 +8,14 @@ const passedAssertion = {
 
 const globalTestStart = {
   name: 'global test',
-  suiteName: undefined,
+  suiteName: null,
   fullName: [
     'global test'
   ]
 };
 const globalTestEnd = {
   name: 'global test',
-  suiteName: undefined,
+  suiteName: null,
   fullName: [
     'global test'
   ],
@@ -111,7 +111,7 @@ const skippedTestEnd1 = {
     'should skip'
   ],
   status: 'skipped',
-  runtime: undefined,
+  runtime: null,
   errors: [],
   assertions: []
 };
@@ -125,7 +125,7 @@ const skippedSuiteEnd = {
   ],
   childSuites: [],
   status: 'skipped',
-  runtime: undefined,
+  runtime: null,
   testCounts: {
     passed: 0,
     failed: 0,
@@ -253,7 +253,7 @@ const skippedTestEnd2 = {
     'should skip'
   ],
   status: 'skipped',
-  runtime: undefined,
+  runtime: null,
   errors: [],
   assertions: []
 };
@@ -414,7 +414,7 @@ const outerSuiteEnd = {
 };
 
 const globalSuiteStart = {
-  name: undefined,
+  name: null,
   fullName: [],
   tests: [
     globalTestStart
@@ -431,7 +431,7 @@ const globalSuiteStart = {
   }
 };
 const globalSuiteEnd = {
-  name: undefined,
+  name: null,
   fullName: [],
   tests: [
     globalTestEnd


### PR DESCRIPTION
Avoid literal undefined as these tend to be needlessly difficult to debug and distinguish from (intentional, or unintentional)
undefined values.

Given the choice, let's go with null.

Fixes https://github.com/js-reporters/js-reporters/issues/124