### PR TITLE
Spec: Combine the "Test" and "Suite" concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,26 +52,25 @@ Would _you_ be interested in discussing this with us further? Please join in!
 Listen to the events and receive the emitted data:
 
 ```js
-// Attach one of the exiting adapters.
+// Use automatic discovery of the framework adapter.
 const runner = JsReporters.autoRegister();
 
-// Listen to the same events for any testing framework.
-runner.on('testEnd', function (test) {
-  console.log('Test %s has errors:', test.fullname.join(' '), test.errors);
+// Listen to standard events, from any testing framework.
+runner.on('testEnd', (test) => {
+  console.log('Test %s has errors:', test.fullName.join(' '), test.errors);
 });
 
-runner.on('runEnd', function (globalSuite) {
-  const testCounts = globalSuite.testCounts;
+runner.on('runEnd', (run) => {
+  const counts = run.counts;
 
-  console.log('Testsuite status: %s', globalSuite.status);
-
+  console.log('Testsuite status: %s', run.status);
   console.log('Total %d tests: %d passed, %d failed, %d skipped',
-    testCounts.total,
-    testCounts.passed,
-    testCounts.failed,
-    testCounts.skipped);
-
-  console.log('Total duration: %d', globalSuite.runtime);
+    counts.total,
+    counts.passed,
+    counts.failed,
+    counts.skipped
+  );
+  console.log('Total duration: %d', run.runtime);
 });
 
 // Or use one of the built-in reporters.

--- a/index.js
+++ b/index.js
@@ -6,9 +6,6 @@ const TapReporter = require('./lib/reporters/TapReporter.js');
 const ConsoleReporter = require('./lib/reporters/ConsoleReporter.js');
 const SummaryReporter = require('./lib/reporters/SummaryReporter.js');
 const {
-  collectSuiteStartData,
-  collectSuiteEndData,
-  createSuiteStart,
   createTestStart
 } = require('./lib/helpers.js');
 const { autoRegister } = require('./lib/auto.js');
@@ -21,9 +18,6 @@ module.exports = {
   ConsoleReporter,
   SummaryReporter,
   EventEmitter,
-  collectSuiteStartData,
-  collectSuiteEndData,
-  createSuiteStart,
   createTestStart,
   autoRegister
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const JasmineAdapter = require('./lib/adapters/JasmineAdapter.js');
 const MochaAdapter = require('./lib/adapters/MochaAdapter.js');
 const TapReporter = require('./lib/reporters/TapReporter.js');
 const ConsoleReporter = require('./lib/reporters/ConsoleReporter.js');
+const SummaryReporter = require('./lib/reporters/SummaryReporter.js');
 const {
   collectSuiteStartData,
   collectSuiteEndData,
@@ -18,6 +19,7 @@ module.exports = {
   MochaAdapter,
   TapReporter,
   ConsoleReporter,
+  SummaryReporter,
   EventEmitter,
   collectSuiteStartData,
   collectSuiteEndData,

--- a/lib/adapters/JasmineAdapter.js
+++ b/lib/adapters/JasmineAdapter.js
@@ -13,9 +13,8 @@ module.exports = class JasmineAdapter extends EventEmitter {
     // NodeJS or browser
     this.env = jasmine.env || jasmine.getEnv();
 
-    this.suiteStarts = {};
     this.suiteChildren = {};
-    this.suiteEnds = {};
+    this.suiteEnds = [];
     this.testStarts = {};
     this.testEnds = {};
 
@@ -56,9 +55,11 @@ module.exports = class JasmineAdapter extends EventEmitter {
 
     return {
       name: testStart.name,
-      suiteName: testStart.suiteName,
+      parentName: testStart.parentName,
       fullName: testStart.fullName.slice(),
       status: (result.status === 'pending') ? 'skipped' : result.status,
+      // TODO: Jasmine 3.4+ has result.duration, use it.
+      // Note that result.duration uses 0 instead of null for a 'skipped' test.
       runtime: (result.status === 'pending') ? null : (new Date() - this.startTime),
       errors,
       assertions
@@ -66,83 +67,78 @@ module.exports = class JasmineAdapter extends EventEmitter {
   }
 
   /**
-   * Convert a Jasmine SuiteResult for CRI 'runStart' or 'suiteStart' event data.
+   * Traverse the Jasmine structured returned by `this.env.topSuite()`
+   * in order to extract the child-parent relations and full names.
    *
-   * Jasmine provides details about childSuites and tests only in the structure
-   * returned by "this.env.topSuite()".
    */
-  createSuiteStart (result, parentNames) {
+  processSuite (result, parentNames, parentIds) {
     const isGlobalSuite = (result.description === 'Jasmine__TopLevel__Suite');
 
     const name = isGlobalSuite ? null : result.description;
     const fullName = parentNames.slice();
-    const tests = [];
-    const childSuites = [];
 
     if (!isGlobalSuite) {
-      fullName.push(result.description);
+      fullName.push(name);
     }
 
+    parentIds.push(result.id);
+    this.suiteChildren[result.id] = [];
+
     result.children.forEach((child) => {
+      this.testStarts[child.id] = {
+        name: child.description,
+        parentName: name,
+        fullName: [...fullName, child.description]
+      };
+
       if (child.id.indexOf('suite') === 0) {
-        childSuites.push(this.createSuiteStart(child, fullName));
+        this.processSuite(child, fullName.slice(), parentIds.slice());
       } else {
-        const testStart = {
-          name: child.description,
-          suiteName: name,
-          fullName: [...fullName, child.description]
-        };
-        tests.push(testStart);
-        this.testStarts[child.id] = testStart;
+        // Update flat list of test children
+        parentIds.forEach((id) => {
+          this.suiteChildren[id].push(child.id);
+        });
       }
     });
-
-    const helperData = helpers.collectSuiteStartData(tests, childSuites);
-    const suiteStart = {
-      name,
-      fullName,
-      tests,
-      childSuites,
-      testCounts: helperData.testCounts
-    };
-    this.suiteStarts[result.id] = suiteStart;
-    this.suiteChildren[result.id] = result.children.map(child => child.id);
-    return suiteStart;
   }
 
-  createSuiteEnd (suiteStart, result) {
-    const tests = [];
-    const childSuites = [];
-    this.suiteChildren[result.id].forEach((childId) => {
-      if (childId.indexOf('suite') === 0) {
-        childSuites.push(this.suiteEnds[childId]);
-      } else {
-        tests.push(this.testEnds[childId]);
-      }
-    });
+  createSuiteEnd (testStart, result) {
+    const tests = this.suiteChildren[result.id].map((testId) => this.testEnds[testId]);
 
-    const helperData = helpers.collectSuiteEndData(tests, childSuites);
+    const helperData = helpers.aggregateTests(tests);
     return {
-      name: suiteStart.name,
-      fullName: suiteStart.fullName,
-      tests,
-      childSuites,
+      name: testStart.name,
+      parentName: testStart.parentName,
+      fullName: testStart.fullName,
       // Jasmine has result.status, but does not propagate 'todo' or 'skipped'
       status: helperData.status,
-      testCounts: helperData.testCounts,
-      // Jasmine 3.4+ has result.duration, but uses 0 instead of null
-      // when 'skipped' is skipped.
-      runtime: helperData.status === 'skipped' ? null : (result.duration || helperData.runtime)
+      runtime: result.duration || helperData.runtime,
+      errors: [],
+      assertions: []
     };
   }
 
   onJasmineStarted () {
-    this.globalSuite = this.createSuiteStart(this.env.topSuite(), []);
-    this.emit('runStart', this.globalSuite);
+    this.processSuite(this.env.topSuite(), [], []);
+
+    let total = 0;
+    this.env.topSuite().children.forEach(function countChild (child) {
+      total++;
+      if (child.id.indexOf('suite') === 0) {
+        child.children.forEach(countChild);
+      }
+    });
+
+    this.emit('runStart', {
+      name: null,
+      counts: {
+        total: total
+      }
+    });
   }
 
   onSuiteStarted (result) {
-    this.emit('suiteStart', this.suiteStarts[result.id]);
+    this.emit('testStart', this.testStarts[result.id]);
   }
 
   onSpecStarted (result) {
@@ -156,11 +152,20 @@ module.exports = class JasmineAdapter extends EventEmitter {
   }
 
   onSuiteDone (result) {
-    this.suiteEnds[result.id] = this.createSuiteEnd(this.suiteStarts[result.id], result);
-    this.emit('suiteEnd', this.suiteEnds[result.id]);
+    const suiteEnd = this.createSuiteEnd(this.testStarts[result.id], result);
+    this.suiteEnds.push(suiteEnd);
+    this.emit('testEnd', suiteEnd);
   }
 
   onJasmineDone (doneInfo) {
-    this.emit('runEnd', this.createSuiteEnd(this.globalSuite, this.env.topSuite()));
+    const topSuite = this.env.topSuite();
+    const tests = this.suiteChildren[topSuite.id].map((testId) => this.testEnds[testId]);
+    const helperData = helpers.aggregateTests([...tests, ...this.suiteEnds]);
+    this.emit('runEnd', {
+      name: null,
+      status: helperData.status,
+      counts: helperData.counts,
+      runtime: helperData.runtime
+    });
   }
 };

--- a/lib/adapters/MochaAdapter.js
+++ b/lib/adapters/MochaAdapter.js
@@ -6,6 +6,14 @@ module.exports = class MochaAdapter extends EventEmitter {
     super();
 
     this.errors = null;
+    this.finalRuntime = 0;
+    this.finalCounts = {
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      todo: 0,
+      total: 0
+    };
 
     // Mocha will instantiate the given function as a class, even if you only need a callback.
     // As such, it can't be an arrow function as those throw TypeError when instantiated.
@@ -27,40 +35,37 @@ module.exports = class MochaAdapter extends EventEmitter {
   convertToSuiteStart (mochaSuite) {
     return {
       name: mochaSuite.title,
-      fullName: this.titlePath(mochaSuite),
-      tests: mochaSuite.tests.map(this.convertTest.bind(this)),
-      childSuites: mochaSuite.suites.map(this.convertToSuiteStart.bind(this)),
-      testCounts: {
-        total: mochaSuite.total()
-      }
+      parentName: (mochaSuite.parent && !mochaSuite.parent.root) ? mochaSuite.parent.title : null,
+      fullName: this.titlePath(mochaSuite)
     };
   }
 
   convertToSuiteEnd (mochaSuite) {
     const tests = mochaSuite.tests.map(this.convertTest.bind(this));
     const childSuites = mochaSuite.suites.map(this.convertToSuiteEnd.bind(this));
-    const helperData = helpers.collectSuiteEndData(tests, childSuites);
+    const helperData = helpers.aggregateTests([...tests, ...childSuites]);
+
     return {
       name: mochaSuite.title,
+      parentName: (mochaSuite.parent && !mochaSuite.parent.root) ? mochaSuite.parent.title : null,
       fullName: this.titlePath(mochaSuite),
-      tests,
-      childSuites,
       status: helperData.status,
-      testCounts: helperData.testCounts,
-      runtime: helperData.runtime
+      runtime: helperData.runtime,
+      errors: [],
+      assertions: []
     };
   }
 
   convertTest (mochaTest) {
-    let suiteName;
+    let parentName;
     let fullName;
     if (!mochaTest.parent.root) {
-      suiteName = mochaTest.parent.title;
+      parentName = mochaTest.parent.title;
       fullName = this.titlePath(mochaTest.parent);
       // Add also the test name.
       fullName.push(mochaTest.title);
     } else {
-      suiteName = null;
+      parentName = null;
       fullName = [mochaTest.title];
     }
 
@@ -73,13 +78,15 @@ module.exports = class MochaAdapter extends EventEmitter {
         message: error.message || error.toString(),
         stack: error.stack
       }));
+      const status = (mochaTest.state === undefined) ? 'skipped' : mochaTest.state;
+      const runtime = (mochaTest.duration === undefined) ? null : mochaTest.duration;
 
       return {
         name: mochaTest.title,
-        suiteName,
+        parentName,
         fullName,
-        status: (mochaTest.state === undefined) ? 'skipped' : mochaTest.state,
-        runtime: (mochaTest.duration === undefined) ? null : mochaTest.duration,
+        status,
+        runtime,
         errors,
         assertions: errors
       };
@@ -87,7 +94,7 @@ module.exports = class MochaAdapter extends EventEmitter {
       // It is a "test start".
       return {
         name: mochaTest.title,
-        suiteName,
+        parentName,
         fullName
       };
     }
@@ -112,15 +119,24 @@ module.exports = class MochaAdapter extends EventEmitter {
   }
 
   onStart () {
-    const globalSuiteStart = this.convertToSuiteStart(this.runner.suite);
-    globalSuiteStart.name = null;
-
-    this.emit('runStart', globalSuiteStart);
+    // total is all tests + all suites
+    // each suite gets a CRI "test" wrapper
+    let total = this.runner.suite.total();
+    this.runner.suite.suites.forEach(function addSuites (suite) {
+      total++;
+      suite.suites.forEach(addSuites);
+    });
+    this.emit('runStart', {
+      name: null,
+      counts: {
+        total: total
+      }
+    });
   }
 
   onSuite (mochaSuite) {
     if (!mochaSuite.root) {
-      this.emit('suiteStart', this.convertToSuiteStart(mochaSuite));
+      this.emit('testStart', this.convertToSuiteStart(mochaSuite));
     }
   }
 
@@ -148,19 +164,29 @@ module.exports = class MochaAdapter extends EventEmitter {
     // and status are already attached to the test, but the errors are not.
     mochaTest.errors = this.errors;
 
-    this.emit('testEnd', this.convertTest(mochaTest));
+    const testEnd = this.convertTest(mochaTest);
+    this.emit('testEnd', testEnd);
+    this.finalCounts.total++;
+    this.finalCounts[testEnd.status]++;
+    this.finalRuntime += testEnd.runtime || 0;
   }
 
   onSuiteEnd (mochaSuite) {
     if (!mochaSuite.root) {
-      this.emit('suiteEnd', this.convertToSuiteEnd(mochaSuite));
+      const testEnd = this.convertToSuiteEnd(mochaSuite);
+      this.emit('testEnd', testEnd);
+      this.finalCounts.total++;
+      this.finalCounts[testEnd.status]++;
+      this.finalRuntime += testEnd.runtime || 0;
     }
   }
 
-  onEnd () {
-    const globalSuiteEnd = this.convertToSuiteEnd(this.runner.suite);
-    globalSuiteEnd.name = null;
-
-    this.emit('runEnd', globalSuiteEnd);
+  onEnd (details) {
+    this.emit('runEnd', {
+      name: null,
+      status: this.finalCounts.failed > 0 ? 'failed' : 'passed',
+      counts: this.finalCounts,
+      runtime: this.finalRuntime
+    });
   }
 };

--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -4,7 +4,7 @@ const helpers = require('../helpers.js');
 /**
  * Known limitations:
  *
- * - Due to ordering issues with nested suites on QUnit < 2.2, this adapter
+ * - Due to ordering issues with nested modules on QUnit < 2.2, this adapter
  *   buffers events and only emits them after the run has completed.
  *   See <https://github.com/js-reporters/js-reporters/pull/60>
  */
@@ -13,9 +13,14 @@ module.exports = class QUnitAdapter extends EventEmitter {
     super();
 
     this.QUnit = QUnit;
-    this.globalSuite = null;
-    this.tests = {};
+    this.testEnds = {};
+    this.moduleEnds = [];
     this.delim = ' > ';
+    this.totalBegin = null;
+
+    // Ordered lists
+    this.globalTests = null;
+    this.globalModules = null;
 
     QUnit.begin(this.onBegin.bind(this));
     QUnit.log(this.onLog.bind(this));
@@ -23,110 +28,128 @@ module.exports = class QUnitAdapter extends EventEmitter {
     QUnit.done(this.onDone.bind(this));
   }
 
-  createSuiteEnd (qunitModule) {
-    const fullName = qunitModule.name ? qunitModule.name.split(this.delim) : [];
-    // Keep only the name of the suite itself.
-    const name = fullName.length ? fullName.slice(-1)[0] : '';
+  prepTestEnd (parentName, parentNames, details) {
+    const testEnd = this.testEnds[details.testId] = {
+      name: details.name,
+      parentName: parentName,
+      fullName: [...parentNames, details.name],
+      // Placeholders, populated by onTestDone() and onLog()
+      status: null,
+      runtime: null,
+      errors: [],
+      assertions: []
+    };
+    return testEnd;
+  }
+
+  processModule (qunitModule) {
+    const fullName = qunitModule.name.split(this.delim);
+    const name = fullName.slice(-1)[0];
+    const parentName = fullName.length >= 2 ? fullName.slice(-2, -1)[0] : null;
+
+    const childTests = qunitModule.tests.map((details) => {
+      return this.prepTestEnd(name, fullName, details);
+    });
 
     return {
-      name,
-      fullName,
-      tests: qunitModule.tests.map((details) => {
-        const testEnd = {
-          name: details.name,
-          suiteName: name,
-          fullName: [...fullName, details.name],
-          // Placeholders, populated by onTestDone() and onLog()()
-          status: null,
-          runtime: null,
-          errors: [],
-          assertions: []
-
-        };
-
-        this.tests[details.testId] = testEnd;
-        return testEnd;
-      }),
-      // Placeholders, populated by createGlobalSuite() and onDone()
-      childSuites: [],
-      status: null,
-      testCounts: null,
-      runtime: null
+      testEnd: {
+        name,
+        parentName,
+        fullName,
+        // Placeholders, populated by emitTests()
+        status: null,
+        runtime: null,
+        errors: [],
+        assertions: []
+      },
+      childTests,
+      childModules: []
     };
   }
 
-  createGlobalSuite () {
-    let globalSuite;
+  processEverything () {
     let modules;
 
-    // Access QUnit internals to get all suites and tests,
+    // Access QUnit internals to get all modules and tests,
     // working around missing event data.
 
-    // Create the global suite first.
+    // First, find any global tests.
     if (this.QUnit.config.modules.length > 0 &&
         this.QUnit.config.modules[0].name === '') {
-      globalSuite = this.createSuiteEnd(this.QUnit.config.modules[0]);
-      // The name of the global suite must be null.
-      globalSuite.name = null;
-      globalSuite.tests.forEach((test) => {
-        test.suiteName = null;
-      });
-
+      this.globalTests = this.QUnit.config.modules[0].tests.map((details) => this.prepTestEnd(null, [], details));
       modules = this.QUnit.config.modules.slice(1);
     } else {
-      globalSuite = {
-        name: null,
-        fullName: [],
-        tests: [],
-        childSuites: [],
-        status: null,
-        testCounts: null,
-        runtime: null
-      };
+      this.globalTests = [];
       modules = this.QUnit.config.modules;
     }
 
-    // Build a list with all suites.
-    const suites = modules.map(this.createSuiteEnd.bind(this));
+    // Prepare all testEnd leafs
+    modules = modules.map(this.processModule.bind(this));
 
-    // If a suite has a composed name, its name will be the last in the sequence
-    // and its parent name will be the one right before it. Search the parent
-    // suite after its name and then add the suite with the composed name to the
-    // childSuites.
-    //
-    // If a suite does not have a composed name, add it to the topLevelSuites,
-    // this means that this suite is the direct child of the global suite.
-    suites.forEach((suite) => {
-      if (suite.fullName.length >= 2) {
-        const parentFullName = suite.fullName.slice(0, -1);
-        suites.forEach((otherSuite) => {
-          if (otherSuite.fullName.join(this.delim) === parentFullName.join(this.delim)) {
-            otherSuite.childSuites.push(suite);
+    // For CRI, each module will be represented as a wrapper test
+    this.totalBegin = Object.keys(this.testEnds).length + modules.length;
+
+    // If a module has a composed name, its name will be the last part of the full name
+    // and its parent name will be the one right before it. Search for the parent
+    // module and add the current module to it as a child, among the test leafs.
+    const globalModules = [];
+    modules.forEach((mod) => {
+      if (mod.testEnd.parentName !== null) {
+        const parentFullName = mod.testEnd.fullName.slice(0, -1);
+        modules.forEach((otherMod) => {
+          if (otherMod.testEnd.fullName.join(this.delim) === parentFullName.join(this.delim)) {
+            otherMod.childModules.push(mod);
           }
         });
       } else {
-        globalSuite.childSuites.push(suite);
+        globalModules.push(mod);
       }
     });
-
-    return globalSuite;
+    this.globalModules = globalModules;
   }
 
-  emitData (suite) {
-    suite.tests.forEach((test) => {
-      this.emit('testStart', helpers.createTestStart(test));
-      this.emit('testEnd', test);
+  emitTests () {
+    this.globalTests.forEach((testEnd) => {
+      this.emit('testStart', helpers.createTestStart(testEnd));
+      this.emit('testEnd', testEnd);
     });
 
-    suite.childSuites.forEach((childSuite) => {
-      this.emit('suiteStart', helpers.createSuiteStart(childSuite));
-      this.emitData(childSuite);
-      this.emit('suiteEnd', childSuite);
-    });
+    const emitModule = (mod) => {
+      this.emit('testStart', helpers.createTestStart(mod.testEnd));
+
+      mod.childTests.forEach((testEnd) => {
+        this.emit('testStart', helpers.createTestStart(testEnd));
+        this.emit('testEnd', testEnd);
+      });
+      mod.childModules.forEach(child => emitModule(child));
+
+      // This is non-recursive and can be because we emit modules in the original
+      // depth-first execution order. We fill in the status/runtime placeholders
+      // for the testEnd object of a nested module, and then later a parent module
+      // follows and sees that child testEnd object by reference and can propagate
+      // and aggregate the information further.
+      const helperData = helpers.aggregateTests([
+        ...mod.childTests,
+        ...mod.childModules.map(child => child.testEnd)
+      ]);
+      mod.testEnd.status = helperData.status;
+      mod.testEnd.runtime = helperData.runtime;
+
+      this.moduleEnds.push(mod.testEnd);
+      this.emit('testEnd', mod.testEnd);
+    };
+    this.globalModules.forEach(emitModule);
   }
 
-  onBegin () {
-    this.globalSuite = this.createGlobalSuite();
+  onBegin (details) {
+    this.processEverything();
+
+    this.emit('runStart', {
+      name: null,
+      counts: {
+        total: this.totalBegin
+      }
+    });
   }
 
   onLog (details) {
@@ -137,16 +160,16 @@ module.exports = class QUnitAdapter extends EventEmitter {
       message: details.message,
       stack: details.source || null
     };
-    if (this.tests[details.testId]) {
+    if (this.testEnds[details.testId]) {
       if (!details.result) {
-        this.tests[details.testId].errors.push(assertion);
+        this.testEnds[details.testId].errors.push(assertion);
       }
-      this.tests[details.testId].assertions.push(assertion);
+      this.testEnds[details.testId].assertions.push(assertion);
     }
   }
 
   onTestDone (details) {
-    const testEnd = this.tests[details.testId];
+    const testEnd = this.testEnds[details.testId];
 
     if (details.failed > 0) {
       testEnd.status = 'failed';
@@ -164,18 +187,20 @@ module.exports = class QUnitAdapter extends EventEmitter {
     }
   }
 
-  onDone () {
-    [this.globalSuite].forEach(function setSuiteEndData (suite) {
-      const helperData = helpers.collectSuiteEndData(suite.tests, suite.childSuites);
-      suite.status = helperData.status;
-      suite.testCounts = helperData.testCounts;
-      suite.runtime = helperData.runtime;
+  onDone (details) {
+    this.emitTests();
 
-      suite.childSuites.forEach(setSuiteEndData);
+    const allTests = [...this.moduleEnds];
+    for (const testId in this.testEnds) {
+      allTests.push(this.testEnds[testId]);
+    }
+    const helperData = helpers.aggregateTests(allTests);
+
+    this.emit('runEnd', {
+      name: null,
+      status: helperData.status,
+      counts: helperData.counts,
+      runtime: details.runtime || null
     });
-
-    this.emit('runStart', helpers.createSuiteStart(this.globalSuite));
-    this.emitData(this.globalSuite);
-    this.emit('runEnd', this.globalSuite);
   }
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,42 +1,3 @@
-// TODO: Remove this function
-function getAllTests (tests, childSuites) {
-  return tests
-    .concat(...childSuites.map(childSuite => getAllTests(childSuite.tests, childSuite.childSuites)));
-}
-
-// TODO: Remove this function
-function collectSuiteStartData (tests, childSuites) {
-  return {
-    counts: {
-      total: getAllTests(tests, childSuites).length
-    }
-  };
-}
-
-// TODO: Remove this function
-function collectSuiteEndData (childTests, childSuites = []) {
-  const all = getAllTests(childTests, childSuites);
-  const counts = {
-    passed: all.filter((test) => test.status === 'passed').length,
-    failed: all.filter((test) => test.status === 'failed').length,
-    skipped: all.filter((test) => test.status === 'skipped').length,
-    todo: all.filter((test) => test.status === 'todo').length,
-    total: all.length
-  };
-  const status = counts.failed > 0 ? 'failed' : 'passed';
-
-  let runtime = 0;
-  all.forEach((test) => {
-    runtime += (test.status === 'skipped' ? 0 : test.runtime);
-  });
-
-  return {
-    status,
-    counts,
-    runtime
-  };
-}
-
 function aggregateTests (all) {
   const counts = {
     passed: all.filter((test) => test.status === 'passed').length,
@@ -59,16 +20,6 @@ function aggregateTests (all) {
   };
 }
 
-// TODO: Remove this function
-function createSuiteStart (suiteEnd) {
-  const parentName = suiteEnd.fullName.slice(-2, -1)[0];
-  return {
-    name: suiteEnd.name,
-    parentName: parentName !== undefined ? parentName : null,
-    fullName: suiteEnd.fullName.slice()
-  };
-}
-
 function createTestStart (testEnd) {
   return {
     name: testEnd.name,
@@ -78,9 +29,6 @@ function createTestStart (testEnd) {
 }
 
 module.exports = {
-  collectSuiteStartData,
-  collectSuiteEndData,
   aggregateTests,
-  createSuiteStart,
   createTestStart
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,68 +1,78 @@
+// TODO: Remove this function
 function getAllTests (tests, childSuites) {
   return tests
     .concat(...childSuites.map(childSuite => getAllTests(childSuite.tests, childSuite.childSuites)));
 }
 
+// TODO: Remove this function
 function collectSuiteStartData (tests, childSuites) {
   return {
-    testCounts: {
+    counts: {
       total: getAllTests(tests, childSuites).length
     }
   };
 }
 
-function collectSuiteEndData (tests, childSuites) {
-  const all = getAllTests(tests, childSuites);
-
-  const testCounts = {
+// TODO: Remove this function
+function collectSuiteEndData (childTests, childSuites = []) {
+  const all = getAllTests(childTests, childSuites);
+  const counts = {
     passed: all.filter((test) => test.status === 'passed').length,
     failed: all.filter((test) => test.status === 'failed').length,
     skipped: all.filter((test) => test.status === 'skipped').length,
     todo: all.filter((test) => test.status === 'todo').length,
     total: all.length
   };
+  const status = counts.failed > 0 ? 'failed' : 'passed';
 
-  let status;
-  if (testCounts.failed > 0) {
-    status = 'failed';
-  } else if (testCounts.skipped > 0 && testCounts.passed === 0) {
-    status = 'skipped';
-  } else if (testCounts.todo > 0 && testCounts.passed === 0) {
-    status = 'todo';
-  } else {
-    status = 'passed';
-  }
-
-  let runtime = null;
-  if (status !== 'skipped') {
-    runtime = all.reduce((sum, test) => {
-      return sum + (test.status === 'skipped' ? 0 : test.runtime);
-    }, 0);
-  }
+  let runtime = 0;
+  all.forEach((test) => {
+    runtime += (test.status === 'skipped' ? 0 : test.runtime);
+  });
 
   return {
     status,
-    testCounts,
+    counts,
     runtime
   };
 }
 
+function aggregateTests (all) {
+  const counts = {
+    passed: all.filter((test) => test.status === 'passed').length,
+    failed: all.filter((test) => test.status === 'failed').length,
+    skipped: all.filter((test) => test.status === 'skipped').length,
+    todo: all.filter((test) => test.status === 'todo').length,
+    total: all.length
+  };
+  const status = counts.failed ? 'failed' : 'passed';
+
+  let runtime = 0;
+  all.forEach((test) => {
+    runtime += test.runtime || 0;
+  });
+
+  return {
+    status,
+    counts,
+    runtime
+  };
+}
+
+// TODO: Remove this function
 function createSuiteStart (suiteEnd) {
+  const parentName = suiteEnd.fullName.slice(-2, -1)[0];
   return {
     name: suiteEnd.name,
-    fullName: suiteEnd.fullName.slice(),
-    tests: suiteEnd.tests.map(createTestStart),
-    childSuites: suiteEnd.childSuites.map(createSuiteStart),
-    testCounts: {
-      total: suiteEnd.testCounts.total
-    }
+    parentName: parentName !== undefined ? parentName : null,
+    fullName: suiteEnd.fullName.slice()
   };
 }
 
 function createTestStart (testEnd) {
   return {
     name: testEnd.name,
-    suiteName: testEnd.suiteName,
+    parentName: testEnd.parentName,
     fullName: testEnd.fullName.slice()
   };
 }
@@ -70,6 +80,7 @@ function createTestStart (testEnd) {
 module.exports = {
   collectSuiteStartData,
   collectSuiteEndData,
+  aggregateTests,
   createSuiteStart,
   createTestStart
 };

--- a/lib/reporters/ConsoleReporter.js
+++ b/lib/reporters/ConsoleReporter.js
@@ -4,18 +4,10 @@ module.exports = class ConsoleReporter {
     // from tests tests that mock the console object itself.
     // https://github.com/js-reporters/js-reporters/issues/125
     this.log = options.log || console.log.bind(console);
-    this.group = (options.log && options.group) || ('group' in console && 'groupEnd' in console
-      ? console.group.bind(console)
-      : () => {});
-    this.groupEnd = (options.log && options.groupEnd) || ('group' in console && 'groupEnd' in console
-      ? console.groupEnd.bind(console)
-      : () => {});
 
     runner.on('runStart', this.onRunStart.bind(this));
-    runner.on('suiteStart', this.onSuiteStart.bind(this));
     runner.on('testStart', this.onTestStart.bind(this));
     runner.on('testEnd', this.onTestEnd.bind(this));
-    runner.on('suiteEnd', this.onSuiteEnd.bind(this));
     runner.on('runEnd', this.onRunEnd.bind(this));
   }
 
@@ -23,13 +15,8 @@ module.exports = class ConsoleReporter {
     return new ConsoleReporter(runner);
   }
 
-  onRunStart (suite) {
-    this.log('runStart', suite);
-  }
-
-  onSuiteStart (suite) {
-    this.group(suite.name);
-    this.log('suiteStart', suite);
+  onRunStart (runStart) {
+    this.log('runStart', runStart);
   }
 
   onTestStart (test) {
@@ -40,12 +27,7 @@ module.exports = class ConsoleReporter {
     this.log('testEnd', test);
   }
 
-  onSuiteEnd (suite) {
-    this.log('suiteEnd', suite);
-    this.groupEnd();
-  }
-
-  onRunEnd (globalSuite) {
-    this.log('runEnd', globalSuite);
+  onRunEnd (runEnd) {
+    this.log('runEnd', runEnd);
   }
 };

--- a/lib/reporters/SummaryReporter.js
+++ b/lib/reporters/SummaryReporter.js
@@ -1,0 +1,106 @@
+const EventEmitter = require('events');
+const hasOwn = Object.hasOwnProperty;
+
+module.exports = class SummaryReporter extends EventEmitter {
+  constructor (runner) {
+    super();
+
+    this.top = {
+      name: null,
+      tests: [],
+      status: null,
+      counts: null,
+      runtime: null
+    };
+
+    // Map of full name to test objects
+    this.attachedTests = {};
+
+    // Map of full name to array of children test objects
+    this.detachedChildren = {};
+
+    this.summary = null;
+
+    runner.on('testEnd', (testEnd) => {
+      const ownFull = testEnd.fullName.join('>');
+      const parentFull = testEnd.fullName.length > 1 ? testEnd.fullName.slice(0, -1).join('>') : null;
+
+      let children;
+      if (hasOwn.call(this.detachedChildren, ownFull)) {
+        children = this.detachedChildren[ownFull];
+        delete this.detachedChildren[ownFull];
+      } else {
+        children = [];
+      }
+
+      const test = {
+        ...testEnd,
+        tests: children
+      };
+
+      if (parentFull === null) {
+        this.top.tests.push(test);
+      } else if (hasOwn.call(this.attachedTests, parentFull)) {
+        this.attachedTests[parentFull].tests.push(test);
+      } else if (hasOwn.call(this.detachedChildren, parentFull)) {
+        this.detachedChildren[parentFull].push(test);
+      } else {
+        this.detachedChildren[parentFull] = [test];
+      }
+
+      this.attachedTests[ownFull] = test;
+    });
+
+    runner.once('runEnd', (runEnd) => {
+      this.top.name = runEnd.name;
+      this.top.status = runEnd.status;
+      this.top.counts = runEnd.counts;
+      this.top.runtime = runEnd.runtime;
+
+      this.summary = this.top;
+
+      this.top = null;
+      this.attachedTests = null;
+      this.detachedChildren = null;
+
+      this.emit('summary', this.summary);
+    });
+  }
+
+  static init (runner) {
+    return new SummaryReporter(runner);
+  }
+
+  /**
+   * Get the summary via callback or Promise.
+   *
+   * @param {Function} [callback]
+   * @param {null|Error} [callback.err]
+   * @param {Object} [callback.summary]
+   * @return {undefined|Promise}
+   */
+  getSummary (callback) {
+    if (callback) {
+      if (this.summary) {
+        callback(null, this.summary);
+      } else {
+        this.once('summary', (summary) => {
+          callback(null, summary);
+        });
+      }
+    } else {
+      // Support IE 9-11: Only reference 'Promise' (which we don't polyfill) when needed.
+      // If the user doesn't use this reporter, or only its callback signature, then it should
+      // work in older browser as well.
+      return new Promise((resolve) => {
+        if (this.summary) {
+          resolve(this.summary);
+        } else {
+          this.once('summary', (summary) => {
+            resolve(summary);
+          });
+        }
+      });
+    }
+  }
+};

--- a/lib/reporters/TapReporter.js
+++ b/lib/reporters/TapReporter.js
@@ -1,5 +1,4 @@
 const kleur = require('kleur');
-
 const hasOwn = Object.hasOwnProperty;
 
 /**

--- a/spec/cri-draft.adoc
+++ b/spec/cri-draft.adoc
@@ -14,13 +14,13 @@ Participate::
   https://gitter.im/js-reporters/js-reporters[Chat room on Gitter]
 
 Last updated::
-  19 September 2020
+  17 January 2021
 
 Abstract::
-  This specification defines APIs for reporting progress and results of JavaScript-based test suites.
+  This specification defines JavaScript APIs for reporting progress and results of executing software tests.
 
 Goal::
-  This specification is meant to be implemented by testing frameworks and consumed by reporters.
+  This specification is meant to be implemented by testing frameworks, reporters, and middleware adapters.
 
 toc::[]
 
@@ -29,66 +29,70 @@ toc::[]
 Testing framework::
   A testing framework is a program that helps define, organize, load, or execute software tests through assertions. (https://en.wikipedia.org/wiki/Test_automation[Learn more])
 
+Adapters::
+  A program that implements the <<producer-api>> on behalf of a testing framework, for example to support testing frameworks that don't yet implement the CRI standard, or to support reporting events from a remotely-executed test run.
+
+Producer::
+  Any JavaScript program that implements the <<producer-api>> of the CRI standard and emit its events, typically this is a testing framework, or an adapter for one.
+
 Assertion::
-  An assertion is a logical preposition required to evaluate to true. Developers and testing frameworks may decide how assertions are evaluated, so long as they produce a single boolean outcome. Assertions must be part of a "Test". (link:https://en.wikipedia.org/wiki/Assertion_(software_development)[Learn more])
+  An assertion is a logical preposition required to evaluate to true. Assertions must be part of a "Test". (link:https://en.wikipedia.org/wiki/Assertion_(software_development)[Learn more])
 
 Passing assertion::
-  An assertion that evaluated to boolean true.
+  An assertion that has evaluated to boolean true.
 
 Failed assertion::
-  An assertion that evaluated to boolean false.
+  An assertion that has evaluated to boolean false.
 
 [[test]] Test::
-  A test is a named group representing zero or more assertions. It is recommended that all tests contain assertions. But, a testing frameworks may choose to only record failed assertions, and thus may report a Test as having no assertions. +
+  A test is a named group containing zero or more assertions, and zero or more child tests. +
    +
-  In QUnit, a test may be defined by calling `QUnit.test()`. +
-  In Mocha and Jasmine BDD, a test may be known as a "spec", defined by calling `it()`.
+  It is recommended that all tests contain assertions, but this is not required. For example, a testing framework that only records failed assertions (such as a testing framework that is decoupled from an assertion library and uses exceptions to discover failures), might not distinguish between a test with passing assertions and a test with no assertions. If a testing framework is generally aware assertions and if it considers absence of those an error, then it should ensure the test or test [[run]] is marked as failing. For example, by implicitly producing a failed assertion. +
+   +
+  A test that contains at least one child test, is also known as a "parent test". +
+   +
+  In QUnit, a test may be defined by calling `QUnit.test()`, and a parent test is known as a "module", defined by calling `QUnit.module()`. +
+  In Mocha and Jasmine BDD, a test is known as a "spec", defined by calling `it()`, with parent tests defined by calling `describe()`. +
+  In JUnit and other xUnit-derivatives, tests are first grouped in a `TestCase` which are then further grouped under a `<testsuite>`. In the CRI standard, both of these are considered a test.
+  (https://en.wikipedia.org/wiki/Test_case[Learn more]) +
 
 Skipped test::
-  A <<test>> that was not executed by the testing framework. Testing frameworks may have ways of selecting, partially loading, filtering, or otherwise skipping tests. These implementation choices may mean that some tests are not considered part of the <<run>>, and thus entirely left out of the information exposed to reporters. Presence of a skipped test does not imply that all skipped tests will be reported. +
+  A <<test>> that was not actually run. Testing frameworks may have ways of selecting, partially loading, filtering, or otherwise skipping tests. These implementation choices may mean that some tests are not considered part of the <<run>>, and thus entirely left out of the information exposed to reporters. Presence of one skipped test does not imply that all skipped tests will be reported in this way. +
    +
   See also the `SKIP` directive of the https://testanything.org/tap-version-13-specification.html#directives[TAP specification].
 
 Todo test::
-  A <<test>> that is expected to have one or more known failing assertions. +
+  A <<test>> that is expected to have one or more failing assertions. +
    +
   See also the `TODO` directive of the https://testanything.org/tap-version-13-specification.html#directives[TAP specification].
 
-[[suite]] Suite::
-  A suite is a named group representing zero or more tests, and zero or more other test suites. A suite that is part of another suite may also be called a "child suite". A suite that holds one or more child suites may also be called an "ancestor suite". +
-  (https://en.wikipedia.org/wiki/Test_case[Learn more]) +
-   +
-  In QUnit, a suite may be known as a "module", defined by calling `QUnit.module()`. +
-  In Mocha and Jasmine BDD, a suite is defined by calling `describe()`. +
-  In JUnit and xUnit-derivatives, tests are first grouped in a `TestCase` which are then further grouped under a `<testsuite>`. In the CRI standard, both of these are considered a suite.
-
 [[run]] Run::
-  A run is the single top-level group representing all tests and test suites loaded together into a testing framework.
+  A run is a single top-level group representing all tests that a producer is planning to report events about.
 
 Reporter::
-  A reporter is a software program that consumes information from a run to then display, store, and/or transport this information in some way. For example to render an HTML graphical user interface, write command-line output in the https://testanything.org/[TAP] format, write results to a https://llg.cubic.org/docs/junit/[JUnit XML] artifact file, or serialize the information and transfer it over a socket to another server or process.
+  A JavaScript program that consumes information from a <<run>>. For example, to render an HTML graphical user interface, to write command-line output in the https://testanything.org/[TAP] format, write results to a https://llg.cubic.org/docs/junit/[JUnit XML] artifact file, or serialize the information and transfer it over a socket to another server or process.
 
 [TIP]
 =====
-The use of "Suite" and "Test" as the main two data structues was decided in in https://github.com/js-reporters/js-reporters/issues/12[issue #12].
+The use of "Test" (and "Parent test") as the main data structure was decided in https://github.com/js-reporters/js-reporters/issues/12[issue #12], and later revised in https://github.com/js-reporters/js-reporters/issues/126[issue #126].
 =====
 
 == Events
 
-These are the events that a testing framework should emit from its <<runner-api>>, and may be consumed by reporters.
+These are the events that a <<producer>> should emit from its <<producer-api>>, for consumption by a <<reporter>>.
 
 [TIP]
 =====
 These events were selected as:
 
-- common across known testing frameworks, as gathered in https://github.com/js-reporters/js-reporters/issues/1#issuecomment-54841874[issue #1].
+- common across known testing frameworks (gathered in https://github.com/js-reporters/js-reporters/issues/1#issuecomment-54841874[issue #1]).
 - valid JavaScript identifiers, allowing use as variable name and as object literal key without quotes.
-- not overlapping with existing events in known testing frameworks, for easy adoption in existing APIs.
+- not overlapping with existing events in known testing frameworks, for easy adoption within existing APIs.
 =====
 
 === Reporting order
 
-It is recommended that events about suites and tests are emitted in **source order**, based on how the tests are defined by the developer in their source code. This means results of tests defined is higher up in a source file should be emitted earlier than those defined lower down in the file.
+It is recommended, though not required, that events about tests are emitted in **source order**, based on how the tests are defined by a developer in a test file. This means results of tests defined is higher up in a test file should be emitted earlier than those defined lower down in the file.
 
 Note that execution order may be different from reporting order. If a testing framework uses concurrency or random seeding for its execution, we recommend that events are still consistently emitted in the source order.
 
@@ -97,185 +101,156 @@ Note that execution order may be different from reporting order. If a testing fr
 Read https://github.com/js-reporters/js-reporters/issues/62[issue #62] for the discussion about reporting order.
 =====
 
-=== Event `runStart`
+=== `runStart` event
 
-The **runStart** event indicates the beginning of a <<run>>. It must be emitted to a reporter exactly once, before any <<event-suitestart>>.
-
-Callback parameters:
-
-* <<suitestart>> **globalSuite**: Describes an implicit <<suite>> that wraps all top-level suites loaded by the framework.
-
-[source,javascript]
-----
-runner.on('runStart', (globalSuite) => { … });
-----
-
-=== Event `runEnd`
-
-The **runEnd** event indicates the end of a <<run>>. It must be emitted to a reporter exactly once, after the last <<event-suiteend>>.
+The **runStart** event indicates the beginning of a <<run>>. It must be emitted exactly once, and before any <<event-teststart>>.
 
 Callback parameters:
 
-* <<suiteend>> **globalSuite**: Describes an implicit <<suite>> that wraps all top-level suites loaded by the framework.
+* <<runstart>> **runStart**: The plan for the run.
 
 [source,javascript]
 ----
-runner.on('runEnd', (globalSuite) => { … });
+producer.on('runStart', (runStart) => { … });
 ----
 
-=== Event `suiteStart`
+=== `runEnd` event
 
-The **suiteStart** event indicates the beginning of a <<suite>>. It must eventually be followed by a corresponding <<event-suiteend>>.
+The **runEnd** event indicates the end of a <<run>>. It must be emitted exactly once, after the last of any <<event-testend>>.
 
 Callback parameters:
 
-* <<suitestart>> **suite**: Describes a <<suite>>.
+* <<runend>> **runEnd**: Summary of test results from the completed run.
 
 [source,javascript]
 ----
-runner.on('suiteStart', (suite) => { … });
+producer.on('runEnd', (runEnd) => { … });
 ----
 
-=== Event `suiteEnd`
+=== `testStart` event
 
-The **suiteEnd** event indicates the end of a <<suite>>. It must be emitted after its corresponding <<event-suiteend>>, and after the last <<event-testend>> of any test belonging to this suite, and after the last <<event-suiteend>> of any child suite belonging to this suite.
+The **testStart** event indicates the beginning of a <<test>>. It must eventually be followed by a corresponding <<event-testend>>. A producer may emit several <<event-teststart,testStart>> events before any corresponding <<event-testend>>, for example when there are child tests, or tests that run concurrently.
 
 Callback parameters:
 
-* <<suiteend>> **suite**: Describes a <<suite>> and each of its tests and child suites.
+* <<teststart>> **testStart**: Basic information about a test.
 
 [source,javascript]
 ----
-runner.on('suiteEnd', (suite) => { … });
+producer.on('testStart', (testStart) => { … });
 ----
 
-=== Event `testStart`
+[TIP]
+=====
+If a producer has no real-time information about test execution, it may simply emit `testStart` back-to-back with `testEnd`.
+=====
 
-The **testStart** event emitted at the beginning of each <<test>>. It must eventually be followed by a corresponding <<event-testend>>.
+=== `testEnd` event
+
+The **testEnd** event indicates the end of a <<test>>. It must be emitted after its corresponding <<event-teststart>>.
 
 Callback parameters:
 
-* <<teststart>> **test**: Describes a <<test>>.
+* <<testend>> **testEnd**: Result of a completed test.
 
 [source,javascript]
 ----
-runner.on('testStart', (test) => { … });
-----
-
-=== Event `testEnd`
-
-The **testEnd** event is emitted at the end of each <<test>>. It must be emitted after its corresponding <<event-suitestart>>.
-
-Callback parameters:
-
-* <<testend>> **test**: Describes a <<test>> and its assertions.
-
-[source,javascript]
-----
-runner.on('testEnd', (test) => { … });
+producer.on('testEnd', (testEnd) => { … });
 ----
 
 == Event data
 
 The following data structures must be implemented as objects that have the specified fields as own properties. The objects are not required to be an instance of any specific class. They may be null-inherited objects, plain objects, or an instance of any public or private class.
 
-=== SuiteStart
+=== RunStart
 
-A **SuiteStart** is a collection of TestStart and other SuiteStart objects.
+The plan for the <<run>>.
 
-`SuiteStart` object:
+`RunStart` object:
 
-* `string|null` **name**: Name of the suite, or `null` for the `globalSuite`.
-* `Array` **fullname**: List of strings containing the name of the suite and the names of all its ancestor suites.
-* `Array<TestStart>` **tests**: List of all tests that belong directly to the suite (not a child suite), as <<teststart>> objects.
-* `Array<SuiteStart>` **childSuites**: List of all direct child suites, as <<suitestart>> objects.
-* `Object` **testCounts**: Aggregate counts about all tests in the suite, including from child suites.
-** `number` **total**: Total number of known tests
+* `string|null` **name**: Name of the overall run, or `null` if the producer is unaware of a name.
+* `Object` **counts**: Aggregate counts about tests.
+** `number|null` **total**: Total number of tests the producer is expecting to emit events for, e.g. if there would be no unexpected failures. If may be `null` if the total is not known ahead of time.
 
-=== SuiteEnd
+=== RunEnd
 
-A **SuiteEnd** is a collection of TestEnd and other SuiteEnd objects, emitted after the suite has been executed, which means that all its tests and child suites have been also executed.
+Summary of test results from the completed <<run>>.
 
-`SuiteEnd` object:
+`RunEnd` object:
 
-* `string|null` **name**: Name of the suite, or `null` for the `globalSuite`.
-* `Array` **fullname**: List of strings containing the name of the suite and the names of all its ancestor suites.
-* `Array<TestEnd>` **tests**: List of all tests that belong directly to the suite (not a child suite), as <<testend>> objects.
-* `Array<SuiteEnd>` **childSuites**: List of all direct child suites, as <<suiteend>> objects.
-* `string` **status**: Aggregate result status of the suite, one of:
-** **failed** if at least one test in the suite or in its child suites has failed.
-** **skipped**, if all tests in the suite and in its child suites were skipped (and there was at least one skipped test).
-** **todo**, if all tests in the suite and in its child suites were todo (and there was at least one todo test).
-** **passed**, if were no failed tests in this suite or in any child suites, this means there was at least one test that executed and passed or there are no tests in this suite.
-* `Object` **testCounts**: Aggregate counts about all tests in the suite, including from child suites.
+* `string|null` **name**: Name of the overall run, or `null` if the producer is unaware of a name.
+* `string` **status**: Aggregate result of all tests, one of:
+** **failed** if at least one test has failed.
+** **passed**, if there were no failed tests, which means there either were no tests, or tests only had passed, skipped, or todo statuses.
+* `Object` **counts**: Aggregate counts about tests.
 ** `number` **passed**: Number of passed tests.
 ** `number` **failed**: Number of failed tests.
 ** `number` **skipped**: Number of skipped tests.
 ** `number` **todo**: Number of todo tests.
-** `number` **total**: Total number of known tests, the sum of the above properties must equal this one.
-* `number` **runtime**: Execution time of the whole suite in milliseconds, including child suites.
+** `number` **total**: Total number of tests, the sum of the above properties must equal this one.
+* `number|null` **runtime**: Optional duration of the run in milliseconds. This may be the sum of the runtime of each test, but may also be higher or lower. For example, it could be higher if the producer includes time spent outside specific tests, or lower if tests run concurrently and the reporter measures observed wall time rather than a sum.
 
 === TestStart
 
-A **TestStart** holds basic information about a <<test>> as it is known before execution.
+Basic information about a <<test>>.
 
 `TestStart` object:
 
 * `string` **name**: Name of the test.
-* `string|null` **suiteName**: Name of the suite the test belongs to, or `null` for the `globalSuite`.
-* `Array<string>` **fullName**: List of strings containing the name of the test, and the names of all ancestor suites.
+* `string|null` **parentName**: Name of the parent test, or `null` if it has no parent.
+* `Array<string>` **fullName**: List of one or more strings, containing (in order) the names of any grand parent tests, the name of any parent test, and the name of the test itself.
 
 === TestEnd
 
-A **TestEnd** holds information about a <<test>> as captured after any execution. This is a superset of <<teststart>>.
+Result of a completed <<test>>. This is a superset of <<teststart>>.
 
 `TestEnd` object:
 
 * `string` **name**: Name of the test.
-* `string|null` **suiteName**: Name of the suite the test belongs to, or `null` for the `globalSuite`.
-* `Array<string>` **fullName**: List of strings containing the name of the test, and the names of all ancestor suites.
+* `string|null` **parentName**: Name of the parent test, or `null` if it has no parent.
+* `Array<string>` **fullName**: List of one or more strings, containing (in order) the names of any grand parent tests, the name of any parent test, and the name of the test itself.
 * `string` **status**: Result of the test, one of:
 ** **passed**, if all assertions have passed, or if no assertions were recorded.
 ** **failed**, if at least one assertion has failed or if the test is todo and its assertions unexpectedly all passed.
-** **skipped**, if the test was intentionally not executed.
+** **skipped**, if the test was intentionally not run.
 ** **todo**, if the test is todo and indeed has at least one failing assertion still.
-* `number` **runtime**: Execution time in milliseconds.
-* `Array<Assertion>` **errors**: List of failed <<assertion>> objects. It will contain at least one error for failed statuses and it will be empty for statuses other than failed.
-* `Array<Assertion>` **assertions**: List of both passed and failed Assertion objects. For a skipped test, this must be an empty array. Testing frameworks that don't record passed assertions may set an empty array for passed tests, and for failed tests in that case this list should contain the same objects as the errors list.
+* `number|null` **runtime**: Optional duration of the run in milliseconds.
+* `Array<Assertion>` **errors**: List of failed <<assertion>> objects. It should contain at least one item for failed tests, and must be empty for other tests.
+* `Array<Assertion>` **assertions**: List of failed and any passed <<assertion>> objects. For a skipped test, this must be empty.
 
 === Assertion
 
-The **Assertion** object contains information about a single <<assertion>>.
+The **Assertion** object contains information about a single assertion.
 
 `Assertion` object:
 
 * `boolean` **passed**: Set to `true` for a passed assertion, `false` for a failed assertion.
 * `Mixed` **actual**: The actual value passed to the assertion, should be similar to `expected` for passed assertions.
 * `Mixed` **expected**: The expected value passed to the assertion, should be similar to `actual` for passed assertions.
-* `string` **message**: Name of the actual value, or description of what the assertion validates.
+* `string` **message**: Name of the assertion, or description of what the assertion checked for.
 * `string|null` **stack**: Optional stack trace. For a "passed" assertion, the property must be set to `null`.
 
-It is allowed for additional non-standard properties to be added to am Assertion object, by the testing framework or a reporter.
+Producers may set additional (non-standard) properties on `Assertion` objects.
 
 [TIP]
 =====
-See https://github.com/js-reporters/js-reporters/issues/79[issue #79] for the discussion that informed which minimum set of properties are part of the emitted Assertion object.
+The properties of the Assertion object was decided in https://github.com/js-reporters/js-reporters/issues/79[issue #79], and later revised by https://github.com/js-reporters/js-reporters/issues/105[issue #105].
 =====
 
-== Runner API
+== Producer API
 
-The Runner API should be implemented by testing frameworks, or CRI standard adapters for testing frameworks. The object on which the Runner API is implemented does not need to be exclusive or otherwise limited to the Runner API. Testing frameworks are encouraged to implement the Runner API as transparently as possible.
+The object on which the Producer API is implemented does not need to be exclusive or otherwise limited to the Producer API. Producers are encouraged to implement the API as transparently as possible.
 
 [TIP]
 =====
-For testing frameworks that provide their main interface through a singleton or global object, the Runner API could be mixed into that main object. For example, `runner.on()` is defined in QUnit as https://api.qunitjs.com/callbacks/QUnit.on/[QUnit.on()].
+For example, a testing framework that provides its main interface through a singleton or global object, could implement the Producer API within that interface. In QUnit, `producer.on()` is implemented as https://api.qunitjs.com/callbacks/QUnit.on/[QUnit.on()].
 
-If the testing framework works through instantiation or through an "environment" instance (such as Jasmine), the Runner API could be exposed as part of that instance instead.
+If the testing framework works through instantiation or through an "environment" instance (such as Jasmine), the Producer API could be implemented by such object instead.
 =====
 
-=== runner.on(eventName, callback)
+=== producer.on(eventName, callback)
 
-Register a callback to be called whenever the specified event is emitted, as described under <<events>>.
+Register a callback to be called whenever the specified event is emitted, as described under <<events>>. May be called multiple times, to register multiple callbacks for a given event.
 
 Parameters:
 
@@ -288,33 +263,33 @@ Return:
 
 [TIP]
 =====
-The `on()` method does not need to be exclusive to CRI standard events. The same event emitter may support additional events custom to the testing framework.
+The `on()` method does not need to be exclusive to CRI standard events. The same event emitter may support other events.
 
-In Node.js, the https://nodejs.org/api/events.html[built-in `events` module] provides an EventEmitter that one could use as the basis for a Runner API implementation. For example:
+In Node.js, the https://nodejs.org/api/events.html[built-in `events` module] provides an EventEmitter that could serve as the basis for a Producer API implementation. For example:
 
 [source,javascript]
 ----
 const EventEmitter = require('events');
-const runner = new EventEmitter();
+const producer = new EventEmitter();
 
-// runner.emit('runStart', { … });
-// runner.emit('runEnd', { … });
+// producer.emit('runStart', { … });
+// producer.emit('runEnd', { … });
 
-module.exports = runner;
+module.exports = producer;
 ----
 =====
 
 == Reporter API
 
-The Reporter API should be implemented by reporters that are intended to be generally useful. It may be implemented in a module with exported functions, or statically on a class.
+The Reporter API can be implemented in as a plain object, a class with static a method, or as exported function.
 
-=== reporter.init(runner)
+=== reporter.init(producer)
 
-Attach the reporter to the <<runner-api,Runner>>.
+Attach the reporter to the <<producer-api,Producer>>.
 
 Parameters:
 
-* <<runner-api,Runner>> **runner**: The main interface of the testing framework.
+* <<producer-api,Producer>> **producer**: The main interface of the testing framework.
 
 Return:
 
@@ -329,12 +304,12 @@ Return:
 [source,javascript,indent=0]
 ----
   class MyReporter {
-    constructor (runner) {
-      // runner.on(…, …);
+    constructor (producer) {
+      // producer.on(…, …);
     }
 
-    static init (runner) {
-      new MyReporter(runner);
+    static init (producer) {
+      new MyReporter(producer);
     }
   }
 
@@ -347,8 +322,8 @@ Return:
 |
 [source,javascript,indent=0]
 ----
-  function init (runner) {
-    // runner.on(…, …);
+  function init (producer) {
+    // producer.on(…, …);
   }
 
   // CommonJS:
@@ -365,7 +340,7 @@ Return:
 
     
 
-// currently being broken on GitHub's adoc renderer.
+// … otherwise broken on GitHub's adoc renderer.
 
 |===
 

--- a/test/fixtures/unit.js
+++ b/test/fixtures/unit.js
@@ -14,12 +14,12 @@ function copyErrors (testEnd) {
 module.exports = {
   passingTestStart: {
     name: 'pass',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['pass']
   },
   passingTest: {
     name: 'pass',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['pass'],
     status: 'passed',
     runtime: 0,
@@ -28,7 +28,6 @@ module.exports = {
   },
   failingTest: copyErrors({
     name: 'fail',
-    suiteName: undefined,
     fullName: ['fail'],
     status: 'failed',
     runtime: 0,
@@ -60,7 +59,7 @@ module.exports = {
   ],
   actualUndefinedTest: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -73,7 +72,7 @@ module.exports = {
   }),
   actualInfinity: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -86,7 +85,7 @@ module.exports = {
   }),
   actualStringChar: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -99,7 +98,7 @@ module.exports = {
   }),
   actualStringNum: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -112,7 +111,7 @@ module.exports = {
   }),
   actualStringBool: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -125,7 +124,7 @@ module.exports = {
   }),
   actualStringOneTailLn: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -145,7 +144,7 @@ module.exports = {
   ...`,
   actualStringTwoTailLn: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -167,7 +166,7 @@ module.exports = {
   ...`,
   actualZero: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -180,7 +179,7 @@ module.exports = {
   }),
   actualArray: copyErrors({
     name: 'Failing',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['Failing'],
     status: 'failed',
     runtime: 0,
@@ -199,7 +198,7 @@ module.exports = {
   ...`,
   expectedUndefinedTest: copyErrors({
     name: 'fail',
-    suiteName: undefined,
+    parentName: null,
     fullName: [],
     status: 'failed',
     runtime: 0,
@@ -212,7 +211,7 @@ module.exports = {
   }),
   expectedFalsyTest: copyErrors({
     name: 'fail',
-    suiteName: undefined,
+    parentName: null,
     fullName: [],
     status: 'failed',
     runtime: 0,
@@ -225,7 +224,7 @@ module.exports = {
   }),
   skippedTest: {
     name: 'skip',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['skip'],
     status: 'skipped',
     runtime: 0,
@@ -234,36 +233,11 @@ module.exports = {
   },
   todoTest: {
     name: 'todo',
-    suiteName: undefined,
+    parentName: null,
     fullName: ['todo'],
     status: 'todo',
     runtime: 0,
     errors: [],
     assertions: []
-  },
-  suiteStart: {
-    name: 'suite name',
-    fullName: ['parent', 'suite name'],
-    tests: [],
-    childSuites: [],
-    testCounts: {
-      total: 2
-    }
-  },
-  suiteEnd: {
-    name: 'suite name',
-    fullName: ['parent', 'suite name'],
-    tests: [],
-    childSuites: [],
-    status: 'passed',
-    testCounts: {
-      passed: 2,
-      failed: 0,
-      skipped: 0,
-      todo: 0,
-      total: 2,
-      extraNested: 40
-    },
-    extraRoot: 20
   }
 };

--- a/test/integration/adapters-run.js
+++ b/test/integration/adapters-run.js
@@ -65,7 +65,7 @@ module.exports = {
     QUnit.load();
   },
   QUnit: function (collectData) {
-    // Get a reporter context independent of the integration test suite itself
+    // Get a reporter context independent of the current integration test
     const QUnit = rerequire('qunit');
     global.QUnit = QUnit;
     QUnit.config.autorun = false;

--- a/test/integration/reference-data.js
+++ b/test/integration/reference-data.js
@@ -8,14 +8,14 @@ const passedAssertion = {
 
 const globalTestStart = {
   name: 'global test',
-  suiteName: null,
+  parentName: null,
   fullName: [
     'global test'
   ]
 };
 const globalTestEnd = {
   name: 'global test',
-  suiteName: null,
+  parentName: null,
   fullName: [
     'global test'
   ],
@@ -29,7 +29,7 @@ const globalTestEnd = {
 
 const passingTestStart1 = {
   name: 'should pass',
-  suiteName: 'suite with passing test',
+  parentName: 'suite with passing test',
   fullName: [
     'suite with passing test',
     'should pass'
@@ -37,20 +37,14 @@ const passingTestStart1 = {
 };
 const passingSuiteStart = {
   name: 'suite with passing test',
+  parentName: null,
   fullName: [
     'suite with passing test'
-  ],
-  tests: [
-    passingTestStart1
-  ],
-  childSuites: [],
-  testCounts: {
-    total: 1
-  }
+  ]
 };
 const passingTestEnd1 = {
   name: 'should pass',
-  suiteName: 'suite with passing test',
+  parentName: 'suite with passing test',
   fullName: [
     'suite with passing test',
     'should pass'
@@ -64,27 +58,19 @@ const passingTestEnd1 = {
 };
 const passingSuiteEnd = {
   name: 'suite with passing test',
+  parentName: null,
   fullName: [
     'suite with passing test'
   ],
-  tests: [
-    passingTestEnd1
-  ],
-  childSuites: [],
   status: 'passed',
-  testCounts: {
-    passed: 1,
-    failed: 0,
-    skipped: 0,
-    todo: 0,
-    total: 1
-  },
-  runtime: 42
+  runtime: 42,
+  errors: [],
+  assertions: []
 };
 
 const skippedTestStart1 = {
   name: 'should skip',
-  suiteName: 'suite with skipped test',
+  parentName: 'suite with skipped test',
   fullName: [
     'suite with skipped test',
     'should skip'
@@ -92,20 +78,14 @@ const skippedTestStart1 = {
 };
 const skippedSuiteStart = {
   name: 'suite with skipped test',
+  parentName: null,
   fullName: [
     'suite with skipped test'
-  ],
-  tests: [
-    skippedTestStart1
-  ],
-  childSuites: [],
-  testCounts: {
-    total: 1
-  }
+  ]
 };
 const skippedTestEnd1 = {
   name: 'should skip',
-  suiteName: 'suite with skipped test',
+  parentName: 'suite with skipped test',
   fullName: [
     'suite with skipped test',
     'should skip'
@@ -117,27 +97,19 @@ const skippedTestEnd1 = {
 };
 const skippedSuiteEnd = {
   name: 'suite with skipped test',
+  parentName: null,
   fullName: [
     'suite with skipped test'
   ],
-  tests: [
-    skippedTestEnd1
-  ],
-  childSuites: [],
-  status: 'skipped',
-  runtime: null,
-  testCounts: {
-    passed: 0,
-    failed: 0,
-    skipped: 1,
-    todo: 0,
-    total: 1
-  }
+  status: 'passed',
+  runtime: 0,
+  errors: [],
+  assertions: []
 };
 
 const failingTestStart1 = {
   name: 'should fail',
-  suiteName: 'suite with failing test',
+  parentName: 'suite with failing test',
   fullName: [
     'suite with failing test',
     'should fail'
@@ -145,20 +117,14 @@ const failingTestStart1 = {
 };
 const failingSuiteStart = {
   name: 'suite with failing test',
+  parentName: null,
   fullName: [
     'suite with failing test'
-  ],
-  tests: [
-    failingTestStart1
-  ],
-  childSuites: [],
-  testCounts: {
-    total: 1
-  }
+  ]
 };
 const failingTestEnd1 = {
   name: 'should fail',
-  suiteName: 'suite with failing test',
+  parentName: 'suite with failing test',
   fullName: [
     'suite with failing test',
     'should fail'
@@ -174,27 +140,19 @@ const failingTestEnd1 = {
 };
 const failingSuiteEnd = {
   name: 'suite with failing test',
+  parentName: null,
   fullName: [
     'suite with failing test'
   ],
-  tests: [
-    failingTestEnd1
-  ],
-  childSuites: [],
   status: 'failed',
-  testCounts: {
-    passed: 0,
-    failed: 1,
-    skipped: 0,
-    todo: 0,
-    total: 1
-  },
-  runtime: 42
+  runtime: 42,
+  errors: [],
+  assertions: []
 };
 
 const passingTestStart2 = {
   name: 'should pass',
-  suiteName: 'suite with tests',
+  parentName: 'suite with tests',
   fullName: [
     'suite with tests',
     'should pass'
@@ -202,7 +160,7 @@ const passingTestStart2 = {
 };
 const passingTestEnd2 = {
   name: 'should pass',
-  suiteName: 'suite with tests',
+  parentName: 'suite with tests',
   fullName: [
     'suite with tests',
     'should pass'
@@ -216,7 +174,7 @@ const passingTestEnd2 = {
 };
 const skippedTestStart2 = {
   name: 'should skip',
-  suiteName: 'suite with tests',
+  parentName: 'suite with tests',
   fullName: [
     'suite with tests',
     'should skip'
@@ -224,7 +182,7 @@ const skippedTestStart2 = {
 };
 const failingTestStart2 = {
   name: 'should fail',
-  suiteName: 'suite with tests',
+  parentName: 'suite with tests',
   fullName: [
     'suite with tests',
     'should fail'
@@ -232,22 +190,14 @@ const failingTestStart2 = {
 };
 const testSuiteStart = {
   name: 'suite with tests',
+  parentName: null,
   fullName: [
     'suite with tests'
-  ],
-  tests: [
-    passingTestStart2,
-    skippedTestStart2,
-    failingTestStart2
-  ],
-  childSuites: [],
-  testCounts: {
-    total: 3
-  }
+  ]
 };
 const skippedTestEnd2 = {
   name: 'should skip',
-  suiteName: 'suite with tests',
+  parentName: 'suite with tests',
   fullName: [
     'suite with tests',
     'should skip'
@@ -259,7 +209,7 @@ const skippedTestEnd2 = {
 };
 const failingTestEnd2 = {
   name: 'should fail',
-  suiteName: 'suite with tests',
+  parentName: 'suite with tests',
   fullName: [
     'suite with tests',
     'should fail'
@@ -275,29 +225,19 @@ const failingTestEnd2 = {
 };
 const testSuiteEnd = {
   name: 'suite with tests',
+  parentName: null,
   fullName: [
     'suite with tests'
   ],
-  tests: [
-    passingTestEnd2,
-    skippedTestEnd2,
-    failingTestEnd2
-  ],
-  childSuites: [],
   status: 'failed',
-  testCounts: {
-    passed: 1,
-    failed: 1,
-    skipped: 1,
-    todo: 0,
-    total: 3
-  },
-  runtime: 84
+  runtime: 84,
+  errors: [],
+  assertions: []
 };
 
 const outerTestStart = {
   name: 'outer test',
-  suiteName: 'outer suite',
+  parentName: 'outer suite',
   fullName: [
     'outer suite',
     'outer test'
@@ -305,7 +245,7 @@ const outerTestStart = {
 };
 const outerTestEnd = {
   name: 'outer test',
-  suiteName: 'outer suite',
+  parentName: 'outer suite',
   fullName: [
     'outer suite',
     'outer test'
@@ -319,7 +259,7 @@ const outerTestEnd = {
 };
 const innerTestStart = {
   name: 'inner test',
-  suiteName: 'inner suite',
+  parentName: 'inner suite',
   fullName: [
     'outer suite',
     'inner suite',
@@ -328,21 +268,15 @@ const innerTestStart = {
 };
 const innerSuiteStart = {
   name: 'inner suite',
+  parentName: 'outer suite',
   fullName: [
     'outer suite',
     'inner suite'
-  ],
-  tests: [
-    innerTestStart
-  ],
-  childSuites: [],
-  testCounts: {
-    total: 1
-  }
+  ]
 };
 const innerTestEnd = {
   name: 'inner test',
-  suiteName: 'inner suite',
+  parentName: 'inner suite',
   fullName: [
     'outer suite',
     'inner suite',
@@ -357,141 +291,93 @@ const innerTestEnd = {
 };
 const innerSuiteEnd = {
   name: 'inner suite',
+  parentName: 'outer suite',
   fullName: [
     'outer suite',
     'inner suite'
   ],
-  tests: [
-    innerTestEnd
-  ],
-  childSuites: [],
   status: 'passed',
-  testCounts: {
-    passed: 1,
-    failed: 0,
-    skipped: 0,
-    todo: 0,
-    total: 1
-  },
-  runtime: 42
+  runtime: 42,
+  errors: [],
+  assertions: []
 };
 
 const outerSuiteStart = {
   name: 'outer suite',
+  parentName: null,
   fullName: [
     'outer suite'
-  ],
-  tests: [
-    outerTestStart
-  ],
-  childSuites: [
-    innerSuiteStart
-  ],
-  testCounts: {
-    total: 2
-  }
+  ]
 };
 const outerSuiteEnd = {
   name: 'outer suite',
+  parentName: null,
   fullName: [
     'outer suite'
   ],
-  tests: [
-    outerTestEnd
-  ],
-  childSuites: [
-    innerSuiteEnd
-  ],
   status: 'passed',
-  testCounts: {
-    passed: 2,
-    failed: 0,
-    skipped: 0,
-    todo: 0,
-    total: 2
-  },
-  runtime: 84
+  runtime: 84,
+  errors: [],
+  assertions: []
 };
 
-const globalSuiteStart = {
+const runStart = {
   name: null,
-  fullName: [],
-  tests: [
-    globalTestStart
-  ],
-  childSuites: [
-    passingSuiteStart,
-    skippedSuiteStart,
-    failingSuiteStart,
-    testSuiteStart,
-    outerSuiteStart
-  ],
-  testCounts: {
-    total: 9
+  counts: {
+    total: 15
   }
 };
-const globalSuiteEnd = {
+const runEnd = {
   name: null,
-  fullName: [],
-  tests: [
-    globalTestEnd
-  ],
-  childSuites: [
-    passingSuiteEnd,
-    skippedSuiteEnd,
-    failingSuiteEnd,
-    testSuiteEnd,
-    outerSuiteEnd
-  ],
   status: 'failed',
-  testCounts: {
-    passed: 5,
-    failed: 2,
+  counts: {
+    passed: 9,
+    failed: 4,
     skipped: 2,
     todo: 0,
-    total: 9
+    total: 15
   },
   runtime: 294
 };
 
 module.exports = [
-  ['runStart', globalSuiteStart],
+  ['runStart', runStart],
 
   ['testStart', globalTestStart],
   ['testEnd', globalTestEnd],
 
-  ['suiteStart', passingSuiteStart],
+  ['testStart', passingSuiteStart],
   ['testStart', passingTestStart1],
   ['testEnd', passingTestEnd1],
-  ['suiteEnd', passingSuiteEnd],
+  ['testEnd', passingSuiteEnd],
 
-  ['suiteStart', skippedSuiteStart],
+  ['testStart', skippedSuiteStart],
   ['testStart', skippedTestStart1],
   ['testEnd', skippedTestEnd1],
-  ['suiteEnd', skippedSuiteEnd],
+  ['testEnd', skippedSuiteEnd],
 
-  ['suiteStart', failingSuiteStart],
+  ['testStart', failingSuiteStart],
   ['testStart', failingTestStart1],
   ['testEnd', failingTestEnd1],
-  ['suiteEnd', failingSuiteEnd],
+  ['testEnd', failingSuiteEnd],
 
-  ['suiteStart', testSuiteStart],
+  ['testStart', testSuiteStart],
   ['testStart', passingTestStart2],
   ['testEnd', passingTestEnd2],
   ['testStart', skippedTestStart2],
   ['testEnd', skippedTestEnd2],
   ['testStart', failingTestStart2],
   ['testEnd', failingTestEnd2],
-  ['suiteEnd', testSuiteEnd],
+  ['testEnd', testSuiteEnd],
 
-  ['suiteStart', outerSuiteStart],
+  ['testStart', outerSuiteStart],
   ['testStart', outerTestStart],
   ['testEnd', outerTestEnd],
-  ['suiteStart', innerSuiteStart],
+  ['testStart', innerSuiteStart],
   ['testStart', innerTestStart],
   ['testEnd', innerTestEnd],
-  ['suiteEnd', innerSuiteEnd],
-  ['suiteEnd', outerSuiteEnd],
+  ['testEnd', innerSuiteEnd],
+  ['testEnd', outerSuiteEnd],
 
-  ['runEnd', globalSuiteEnd]
+  ['runEnd', runEnd]
 ];

--- a/test/unit/console-reporter.js
+++ b/test/unit/console-reporter.js
@@ -10,9 +10,7 @@ QUnit.module('ConsoleReporter', hooks => {
     emitter = new JsReporters.EventEmitter();
     sandbox = sinon.sandbox.create();
     con = {
-      log: sandbox.stub(),
-      group: sandbox.stub(),
-      groupEnd: sandbox.stub()
+      log: sandbox.stub()
     };
     // eslint-disable-next-line no-new
     new JsReporters.ConsoleReporter(emitter, con);
@@ -30,18 +28,6 @@ QUnit.module('ConsoleReporter', hooks => {
   test('Event "runEnd"', assert => {
     emitter.emit('runEnd', {});
     assert.equal(con.log.callCount, 1);
-  });
-
-  test('Event "suiteStart"', assert => {
-    emitter.emit('suiteStart', {});
-    assert.equal(con.log.callCount, 1);
-    assert.equal(con.group.callCount, 1);
-  });
-
-  test('Event "suiteEnd"', assert => {
-    emitter.emit('suiteEnd', {});
-    assert.equal(con.log.callCount, 1);
-    assert.equal(con.groupEnd.callCount, 1);
   });
 
   test('Event "testStart"', assert => {

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -64,14 +64,7 @@ QUnit.module('Helpers', function () {
     });
   });
 
-  QUnit.module('create functions', function () {
-    test('return a suite start', assert => {
-      assert.propEqual(
-        JsReporters.createSuiteStart(data.suiteEnd),
-        data.suiteStart
-      );
-    });
-
+  QUnit.module('create functions', () => {
     test('return a test start', assert => {
       assert.propEqual(
         JsReporters.createTestStart(data.passingTest),

--- a/test/unit/summary-reporter.js
+++ b/test/unit/summary-reporter.js
@@ -1,0 +1,225 @@
+/* eslint-env qunit */
+const { test } = QUnit;
+const JsReporters = require('../../index.js');
+
+// Generally in test frameworks, a parent ends after its children
+// have finished. Thus we build the tree "upwards", from the inside out.
+function playUpwardRun (emitter) {
+  emitter.emit('runStart', {
+    name: null,
+    counts: {
+      total: 2
+    }
+  });
+  emitter.emit('testEnd', {
+    name: 'foo',
+    parentName: 'Inner suite',
+    fullName: ['Outer suite', 'Inner suite', 'foo'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: [
+      { passed: true }
+    ]
+  });
+  emitter.emit('testEnd', {
+    name: 'bar',
+    parentName: 'Inner suite',
+    fullName: ['Outer suite', 'Inner suite', 'bar'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: [
+      { passed: true }
+    ]
+  });
+  emitter.emit('testEnd', {
+    name: 'Inner suite',
+    parentName: 'Outer suite',
+    fullName: ['Outer suite', 'Inner suite'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: []
+  });
+  emitter.emit('testEnd', {
+    name: 'Outer suite',
+    parentName: null,
+    fullName: ['Outer suite'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: []
+  });
+  emitter.emit('runEnd', {
+    name: null,
+    status: 'passed',
+    counts: {
+      passed: 4,
+      failed: 0,
+      skipped: 0,
+      todo: 0,
+      total: 4
+    },
+    runtime: 42
+  });
+}
+
+// But we support receiving events in any order,
+// so test the reverse as well.
+function playDownwardRun (emitter) {
+  emitter.emit('runStart', {
+    name: null,
+    counts: {
+      total: 2
+    }
+  });
+  emitter.emit('testEnd', {
+    name: 'Outer suite',
+    parentName: null,
+    fullName: ['Outer suite'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: []
+  });
+  emitter.emit('testEnd', {
+    name: 'Inner suite',
+    parentName: 'Outer suite',
+    fullName: ['Outer suite', 'Inner suite'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: []
+  });
+  emitter.emit('testEnd', {
+    name: 'foo',
+    parentName: 'Inner suite',
+    fullName: ['Outer suite', 'Inner suite', 'foo'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: [
+      { passed: true }
+    ]
+  });
+  emitter.emit('testEnd', {
+    name: 'bar',
+    parentName: 'Inner suite',
+    fullName: ['Outer suite', 'Inner suite', 'bar'],
+    status: 'passed',
+    runtime: 42,
+    errors: [],
+    assertions: [
+      { passed: true }
+    ]
+  });
+  emitter.emit('runEnd', {
+    name: null,
+    status: 'passed',
+    counts: {
+      passed: 4,
+      failed: 0,
+      skipped: 0,
+      todo: 0,
+      total: 4
+    },
+    runtime: 42
+  });
+}
+
+const expectedSummary = {
+  name: null,
+  tests: [
+    {
+      name: 'Outer suite',
+      parentName: null,
+      fullName: ['Outer suite'],
+      status: 'passed',
+      runtime: 42,
+      errors: [],
+      assertions: [],
+      tests: [
+        {
+          name: 'Inner suite',
+          parentName: 'Outer suite',
+          fullName: ['Outer suite', 'Inner suite'],
+          status: 'passed',
+          runtime: 42,
+          errors: [],
+          assertions: [],
+          tests: [
+            {
+              name: 'foo',
+              parentName: 'Inner suite',
+              fullName: ['Outer suite', 'Inner suite', 'foo'],
+              status: 'passed',
+              runtime: 42,
+              errors: [],
+              assertions: [
+                { passed: true }
+              ],
+              tests: []
+            },
+            {
+              name: 'bar',
+              parentName: 'Inner suite',
+              fullName: ['Outer suite', 'Inner suite', 'bar'],
+              status: 'passed',
+              runtime: 42,
+              errors: [],
+              assertions: [
+                { passed: true }
+              ],
+              tests: []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  status: 'passed',
+  counts: {
+    passed: 4,
+    failed: 0,
+    skipped: 0,
+    todo: 0,
+    total: 4
+  },
+  runtime: 42
+};
+
+QUnit.module('SummaryReporter', hooks => {
+  let emitter, reporter;
+
+  hooks.beforeEach(function () {
+    emitter = new JsReporters.EventEmitter();
+    reporter = JsReporters.SummaryReporter.init(emitter);
+  });
+
+  test('getSummary() with upward events', async assert => {
+    playUpwardRun(emitter);
+    assert.propEqual(
+      await reporter.getSummary(),
+      expectedSummary
+    );
+  });
+
+  test('getSummary() with downward events', async assert => {
+    playDownwardRun(emitter);
+    assert.propEqual(
+      await reporter.getSummary(),
+      expectedSummary
+    );
+  });
+
+  test('getSummary(callback)', async assert => {
+    const done = assert.async();
+    playUpwardRun(emitter);
+    reporter.getSummary((err, summary) => {
+      assert.strictEqual(err, null);
+      assert.propEqual(summary, expectedSummary);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Status quo

The TAP 13 specification does not standardise a way of describing parent-child relationships between tests, nor does it standardise how to group tests.

Yet, all major test frameworks have a way to group tests (e.g. QUnit module, and Mocha suite) and/or allow nesting tests inside of other tests (like tape, and node-tap). While the CRI draft provided a way to group tests, it did not accomodate Tap. They would either need to flatten the tests with a separator symbol in the test name, or to create an implied "Suite" for every test that has non-zero children and then come up with an ad-hoc naming scheme for it.

Note that the TAP 13 reporter we ship, even after this change, still ends up flattening the tests by defaut using the greater than `>` symbol, but at least the event model itself recognises the relationships so that other output formats can make use of it, and in the future TAP 14 hopefully will recognise it as well, which we can then make use of.

Ref https://github.com/TestAnything/testanything.github.io/pull/36.

### Summary of changes

See the diff of `test/integration/reference-data.js` for the concrete changes this makes to the consumable events.

- Remove `suiteStart` and `suiteEnd` events.

  Instead, the spec now says that tests are permitted to have children.

  The link from child to parent remains the same as before, using the `fullName` field which is now a stack of test names. Previously, it was a stack of suite names with a test name at the end.

- Remove all "downward" links from parent to child. Tests don't describe their children upfront in detail, and neither does `runStart`. This was information was very repetitive and tedious to satisy for implementors, and encouraged or required inefficient use of memory.

  I do recognise that a common use case might be to generate a single output file or stream where real-time updates are not needed, in which case you may want a convenient tree that is ready to traverse without needing to listen for async events and put it together. For this purpose, I have added a built-in reporter that simply listens to the new events and outputs a "summary" event with an object that is similar to the old "runEnd" event object where the entire run is described in a single large object.

- New "SummaryReporter" for simple use cases of non-realtime traversing of single structure after the test has completed.

### Caveats

- A test with the "failed" status is no longer expected to always have an error directly associated with it.

  Now that tests aggregate into other tests rather than into suites, this means tests that merely have other tests as children do still have to send a full testEnd event, and thus an `errors` and `assertions` array.

  I considered specifying that errors have to propagate but this seemed messy and could lead to duplicate diagnostic output in  reporters, as well ambiguity or uncertainty over where errors originated.

- A suite containing only "skipped" tests now aggregates as "passed" instead of "skipped". Given we can't know whether a suite is its own test with its own assertions, we also can't assume that if a test parent has only "skipped" children that the parent was also skipped.

  This applies to our built-in adapters, but individual frameworks, if they know that a suite was skipped in its entirety, can of course still set the status of parents however they see fit.

- Graphical reporters (such as QUnit and Mocha's HTML reporters) may no longer assume that a test parent has either assertions/errors or other tests. A test parent can now have both its own assertions/errors, as well as other tests beneath it.

  This restricts the freedom and possibilities for visualisation. My recommendation is that, if a visual reporter wants to keep using different visual shapes for "group of assertions" and "group of tests", that they buffer the information internally such that they can first render all the tests's own assertions, and then render the children, even if they originally ran interleaved and/or the other way around.

  Ref https://github.com/js-reporters/js-reporters/issues/126.

- The "Console" reporter that comes with js-reporter now no longer uses `console.group()` for collapsing nested tests.

### Misc

- Add definitions for the "Adapter" and "Producer" terms.

- Use terms "producer" and "reporter" consistently, instead of "framework", "runner", or "adapter".

- Remove mention that the spec is for reporting information from "JavaScript test frameworks". CRI can be used to report information about any kind of test that can be represented in CRI's event model, including linting and end-to-end tests for JS programs, as well as non-JS programs. It describes a JS interface for reporters, but the information can come from anywhere.

  This further solifies that CRI is not meant to be used for "hooking" into a framework, and sets no expectation about timing or run-time environment being shared with whatever is executing tests in some form or another. This was already the intent originally, since it could be used to report information from other processes or from a cloud-based test runner like BrowserStack, but this removes any remaining confusion or doubt there may have been.

Fixes https://github.com/js-reporters/js-reporters/issues/126.

