### PR TITLE
Reporter: Recognise "Todo" tests from QUnit

### DIFF
--- a/lib/adapters/QUnitAdapter.js
+++ b/lib/adapters/QUnitAdapter.js
@@ -170,10 +170,15 @@ module.exports = class QUnitAdapter extends EventEmitter {
   onTestDone (details) {
     const testEnd = this.testEnds[details.testId];
 
-    if (details.failed > 0) {
-      testEnd.status = 'failed';
-    } else if (details.skipped) {
+    // Handle todo status
+    const netFailure = (details.failed > 0 && !details.todo) || (details.failed === 0 && details.todo);
+
+    if (details.skipped) {
       testEnd.status = 'skipped';
+    } else if (netFailure) {
+      testEnd.status = 'failed';
+    } else if (details.todo) {
+      testEnd.status = 'todo';
     } else {
       testEnd.status = 'passed';
     }

--- a/test/fixtures/integration/qunit-todo.js
+++ b/test/fixtures/integration/qunit-todo.js
@@ -1,0 +1,22 @@
+/* global QUnit */
+
+QUnit.test('global pass', function (assert) {
+  assert.ok(true);
+});
+
+QUnit.todo('global todo', function (assert) {
+  assert.ok(false);
+});
+
+QUnit.module('suite with a todo test');
+QUnit.test('should pass', function (assert) {
+  assert.ok(true);
+});
+QUnit.todo('should todo', function (assert) {
+  assert.ok(false);
+});
+
+QUnit.module.todo('todo suite');
+QUnit.test('should todo', function (assert) {
+  assert.ok(false);
+});

--- a/test/integration/adapters-run.js
+++ b/test/integration/adapters-run.js
@@ -20,7 +20,7 @@ function rerequire (file) {
  * Exports a function for each adapter that will run
  * against a default test fixture.
  */
-module.exports = {
+module.exports.main = {
   Jasmine: function (collectData) {
     const Jasmine = rerequire('jasmine');
     const jasmine = new Jasmine();
@@ -88,5 +88,20 @@ module.exports = {
 
     collectData(mochaRunner);
     mocha.run();
+  }
+};
+
+module.exports.todo = {
+  QUnit: function (collectData) {
+    const QUnit = rerequire('qunit');
+    global.QUnit = QUnit;
+    QUnit.config.autorun = false;
+
+    const qunitRunner = new JsReporters.QUnitAdapter(QUnit);
+    collectData(qunitRunner);
+
+    rerequire(path.join(testDir, 'qunit-todo.js'));
+
+    QUnit.start();
   }
 };

--- a/test/integration/adapters.js
+++ b/test/integration/adapters.js
@@ -94,118 +94,127 @@ function fixExpectedData (adapter, expectedData) {
   });
 }
 
-QUnit.module('Adapters integration', function () {
-  Object.keys(runAdapters).forEach(function (adapter) {
-    QUnit.module(adapter + ' adapter', hooks => {
-      // Re-require for each adapter because we change the expected data.
-      const expectedData = rerequire('./reference-data.js');
-      fixExpectedData(adapter, expectedData);
+const integrations = [
+  { key: 'main', name: 'Adapters main integration', referenceFile: './reference-data.js' },
 
-      const collectedData = [];
+  // This is only implemented by QUnit currently
+  { key: 'todo', name: 'Adapters todo integration', referenceFile: './reference-data-todo.js' }
+];
 
-      hooks.before(assert => {
-        const done = assert.async();
-        runAdapters[adapter](
-          collectDataFromRunner.bind(null, collectedData, done)
-        );
-      });
+integrations.forEach(function (integration) {
+  QUnit.module(integration.name, function () {
+    Object.keys(runAdapters[integration.key]).forEach(function (adapter) {
+      QUnit.module(adapter + ' adapter', hooks => {
+        // Re-require for each adapter because we mutate the expected data.
+        const expectedData = rerequire(integration.referenceFile);
+        fixExpectedData(adapter, expectedData);
 
-      // Fist check that, overall, all expected events were emitted and in order.
-      test('Emitted events names', assert => {
-        assert.propEqual(
-          collectedData.map(pair => pair[0]),
-          expectedData.map(pair => pair[0]),
-          'Event names'
-        );
-      });
+        const collectedData = [];
 
-      test('Event "testStart" data', assert => {
-        const actuals = collectedData.filter(pair => pair[0] === 'testStart');
-        const expecteds = expectedData.filter(pair => pair[0] === 'testStart');
-        assert.propEqual(
-          actuals.map(expected => expected[1].name),
-          expecteds.map(pair => pair[1].name),
-          'Test names'
-        );
-        expecteds.forEach((expected, i) => {
-          assert.propEqual(
-            actuals[i][1],
-            expected[1],
-            `Event data for testStart#${i}`
+        hooks.before(assert => {
+          const done = assert.async();
+          runAdapters[integration.key][adapter](
+            collectDataFromRunner.bind(null, collectedData, done)
           );
         });
-      });
 
-      test('Event "testEnd" data', assert => {
-        const actuals = collectedData.filter(pair => pair[0] === 'testEnd');
-        const expecteds = expectedData.filter(pair => pair[0] === 'testEnd');
-        assert.propEqual(
-          actuals.map(expected => expected[1].name),
-          expecteds.map(pair => pair[1].name),
-          'Test names'
-        );
-        expecteds.forEach((expected, i) => {
+        // Fist check that, overall, all expected events were emitted and in order.
+        test('Emitted events names', assert => {
           assert.propEqual(
-            actuals[i][1],
-            expected[1],
-            `Event data for testEnd#${i}`
+            collectedData.map(pair => pair[0]),
+            expectedData.map(pair => pair[0]),
+            'Event names'
           );
         });
-      });
 
-      test('Event "suiteStart" data', assert => {
-        const actuals = collectedData.filter(pair => pair[0] === 'suiteStart');
-        const expecteds = expectedData.filter(pair => pair[0] === 'suiteStart');
-        assert.propEqual(
-          actuals.map(expected => expected[1].name),
-          expecteds.map(pair => pair[1].name),
-          'Suite names'
-        );
-        expecteds.forEach((expected, i) => {
+        test('Event "testStart" data', assert => {
+          const actuals = collectedData.filter(pair => pair[0] === 'testStart');
+          const expecteds = expectedData.filter(pair => pair[0] === 'testStart');
           assert.propEqual(
-            actuals[i][1],
-            expected[1],
-            `Event data for suiteStart#${i}`
+            actuals.map(expected => expected[1].name),
+            expecteds.map(pair => pair[1].name),
+            'Test names'
           );
+          expecteds.forEach((expected, i) => {
+            assert.propEqual(
+              actuals[i][1],
+              expected[1],
+              `Event data for testStart#${i}`
+            );
+          });
         });
-      });
 
-      test('Event "suiteEnd" data', assert => {
-        const actuals = collectedData.filter(pair => pair[0] === 'suiteEnd');
-        const expecteds = expectedData.filter(pair => pair[0] === 'suiteEnd');
-        assert.propEqual(
-          actuals.map(expected => expected[1].name),
-          expecteds.map(pair => pair[1].name),
-          'Suite names'
-        );
-        expecteds.forEach((expected, i) => {
+        test('Event "testEnd" data', assert => {
+          const actuals = collectedData.filter(pair => pair[0] === 'testEnd');
+          const expecteds = expectedData.filter(pair => pair[0] === 'testEnd');
           assert.propEqual(
-            actuals[i][1],
-            expected[1],
-            `Event data for suiteEnd#${i}`
+            actuals.map(expected => expected[1].name),
+            expecteds.map(pair => pair[1].name),
+            'Test names'
           );
+          expecteds.forEach((expected, i) => {
+            assert.propEqual(
+              actuals[i][1],
+              expected[1],
+              `Event data for testEnd#${i}`
+            );
+          });
         });
-      });
 
-      test('Event "runStart" data', assert => {
-        const actuals = collectedData.filter(pair => pair[0] === 'runStart');
-        expectedData.filter(pair => pair[0] === 'runStart').forEach((expected, i) => {
+        test('Event "suiteStart" data', assert => {
+          const actuals = collectedData.filter(pair => pair[0] === 'suiteStart');
+          const expecteds = expectedData.filter(pair => pair[0] === 'suiteStart');
           assert.propEqual(
-            actuals[i][1],
-            expected[1],
-            `Event data for runStart#${i}`
+            actuals.map(expected => expected[1].name),
+            expecteds.map(pair => pair[1].name),
+            'Suite names'
           );
+          expecteds.forEach((expected, i) => {
+            assert.propEqual(
+              actuals[i][1],
+              expected[1],
+              `Event data for suiteStart#${i}`
+            );
+          });
         });
-      });
 
-      test('Event "runEnd" data', assert => {
-        const actuals = collectedData.filter(pair => pair[0] === 'runEnd');
-        expectedData.filter(pair => pair[0] === 'runEnd').forEach((expected, i) => {
+        test('Event "suiteEnd" data', assert => {
+          const actuals = collectedData.filter(pair => pair[0] === 'suiteEnd');
+          const expecteds = expectedData.filter(pair => pair[0] === 'suiteEnd');
           assert.propEqual(
-            actuals[i][1],
-            expected[1],
-            `Event data for runEnd#${i}`
+            actuals.map(expected => expected[1].name),
+            expecteds.map(pair => pair[1].name),
+            'Suite names'
           );
+          expecteds.forEach((expected, i) => {
+            assert.propEqual(
+              actuals[i][1],
+              expected[1],
+              `Event data for suiteEnd#${i}`
+            );
+          });
+        });
+
+        test('Event "runStart" data', assert => {
+          const actuals = collectedData.filter(pair => pair[0] === 'runStart');
+          expectedData.filter(pair => pair[0] === 'runStart').forEach((expected, i) => {
+            assert.propEqual(
+              actuals[i][1],
+              expected[1],
+              `Event data for runStart#${i}`
+            );
+          });
+        });
+
+        test('Event "runEnd" data', assert => {
+          const actuals = collectedData.filter(pair => pair[0] === 'runEnd');
+          expectedData.filter(pair => pair[0] === 'runEnd').forEach((expected, i) => {
+            assert.propEqual(
+              actuals[i][1],
+              expected[1],
+              `Event data for runEnd#${i}`
+            );
+          });
         });
       });
     });

--- a/test/integration/reference-data-todo.js
+++ b/test/integration/reference-data-todo.js
@@ -1,0 +1,194 @@
+const failedAssertion = {
+  passed: false
+};
+
+const passedAssertion = {
+  passed: true
+};
+
+const globalPassStart = {
+  name: 'global pass',
+  suiteName: null,
+  fullName: [
+    'global pass'
+  ]
+};
+const globalPassEnd = {
+  name: 'global pass',
+  suiteName: null,
+  fullName: [
+    'global pass'
+  ],
+  status: 'passed',
+  runtime: 42,
+  errors: [],
+  assertions: [
+    passedAssertion
+  ]
+};
+
+const globalTodoStart = {
+  name: 'global todo',
+  suiteName: null,
+  fullName: [
+    'global todo'
+  ]
+};
+const globalTodoEnd = {
+  name: 'global todo',
+  suiteName: null,
+  fullName: [
+    'global todo'
+  ],
+  status: 'todo',
+  runtime: 42,
+  errors: [
+    failedAssertion
+  ],
+  assertions: [
+    failedAssertion
+  ]
+};
+
+const suite1Start = {
+  name: 'suite with a todo test',
+  fullName: [
+    'suite with a todo test'
+  ]
+};
+const passInSuite1Start = {
+  name: 'should pass',
+  suiteName: 'suite with a todo test',
+  fullName: [
+    'suite with a todo test',
+    'should pass'
+  ]
+};
+const passInSuite1End = {
+  name: 'should pass',
+  suiteName: 'suite with a todo test',
+  fullName: [
+    'suite with a todo test',
+    'should pass'
+  ],
+  status: 'passed',
+  runtime: 42,
+  errors: [],
+  assertions: [
+    passedAssertion
+  ]
+};
+const todoInSuite1Start = {
+  name: 'should todo',
+  suiteName: 'suite with a todo test',
+  fullName: [
+    'suite with a todo test',
+    'should todo'
+  ]
+};
+const todoInSuite1End = {
+  name: 'should todo',
+  suiteName: 'suite with a todo test',
+  fullName: [
+    'suite with a todo test',
+    'should todo'
+  ],
+  status: 'todo',
+  runtime: 42,
+  errors: [
+    failedAssertion
+  ],
+  assertions: [
+    failedAssertion
+  ]
+};
+const suite1End = {
+  name: 'suite with a todo test',
+  fullName: [
+    'suite with a todo test'
+  ],
+  status: 'passed',
+  runtime: 42
+};
+
+const suite2Start = {
+  name: 'todo suite',
+  fullName: [
+    'todo suite'
+  ]
+};
+const todoInSuite2Start = {
+  name: 'should todo',
+  suiteName: 'todo suite',
+  fullName: [
+    'todo suite',
+    'should todo'
+  ]
+};
+const todoInSuite2End = {
+  name: 'should todo',
+  suiteName: 'todo suite',
+  fullName: [
+    'todo suite',
+    'should todo'
+  ],
+  status: 'todo',
+  runtime: 42,
+  errors: [
+    failedAssertion
+  ],
+  assertions: [
+    failedAssertion
+  ]
+};
+const suite2End = {
+  name: 'todo suite',
+  fullName: [
+    'todo suite'
+  ],
+  status: 'passed',
+  runtime: 42
+};
+
+const runStart = {
+  name: null,
+  testCounts: {
+    total: 7
+  }
+};
+const runEnd = {
+  name: null,
+  status: 'passed',
+  testCounts: {
+    passed: 4,
+    failed: 0,
+    skipped: 0,
+    todo: 3,
+    total: 7
+  },
+  runtime: 42
+};
+
+module.exports = [
+  ['runStart', runStart],
+
+  ['testStart', globalPassStart],
+  ['testEnd', globalPassEnd],
+
+  ['testStart', globalTodoStart],
+  ['testEnd', globalTodoEnd],
+
+  ['suiteStart', suite1Start],
+  ['testStart', passInSuite1Start],
+  ['testEnd', passInSuite1End],
+  ['testStart', todoInSuite1Start],
+  ['testEnd', todoInSuite1End],
+  ['suiteEnd', suite1End],
+
+  ['suiteStart', suite2Start],
+  ['testStart', todoInSuite2Start],
+  ['testEnd', todoInSuite2End],
+  ['suiteEnd', suite2End],
+
+  ['runEnd', runEnd]
+];


### PR DESCRIPTION
This wasn't previously done because versions that support this feature also have a jsreporters-compatible event emitter built-in, but this isn't always used (such as in browserstack-runner). So for completion support it here as well just in case.

Ref https://github.com/qunitjs/qunit/issues/1622.